### PR TITLE
Add components for GitHubSource

### DIFF
--- a/pkg/components/config.go
+++ b/pkg/components/config.go
@@ -16,9 +16,20 @@
 
 package components
 
-import "knative.dev/reconciler-test/pkg/components/eventing"
+import (
+	"knative.dev/pkg/apis"
+	"knative.dev/reconciler-test/pkg/components/eventing"
+	"knative.dev/reconciler-test/pkg/components/networking"
+	"knative.dev/reconciler-test/pkg/components/serving"
+)
 
-// ComponentConfig is the aggregation of component configurations.
-type ComponentConfig struct {
-	Eventing eventing.EventingConfig
+// Config is the aggregation of component configurations.
+type Config struct {
+	Eventing   eventing.Config
+	Serving    serving.Config
+	Networking networking.Config
+}
+
+func (c *Config) Validate() *apis.FieldError {
+	return nil
 }

--- a/pkg/components/eventing/config.go
+++ b/pkg/components/eventing/config.go
@@ -16,9 +16,16 @@
 
 package eventing
 
-import "knative.dev/reconciler-test/pkg/components/eventing/sources"
+import (
+	"knative.dev/pkg/apis"
+	"knative.dev/reconciler-test/pkg/components/eventing/sources"
+)
 
-// EventingConfig is the aggregation of eventing configurations.
-type EventingConfig struct {
-	Sources sources.SourcesConfig
+// Config is the aggregation of eventing configurations.
+type Config struct {
+	Sources sources.Config
+}
+
+func (c *Config) Validate() *apis.FieldError {
+	return nil
 }

--- a/pkg/components/eventing/sources/config.go
+++ b/pkg/components/eventing/sources/config.go
@@ -16,9 +16,16 @@
 
 package sources
 
-import "knative.dev/reconciler-test/pkg/components/eventing/sources/github"
+import (
+	"knative.dev/pkg/apis"
+	"knative.dev/reconciler-test/pkg/components/eventing/sources/github"
+)
 
-// SourcesConfig is the aggregation of eventing sources configurations.
-type SourcesConfig struct {
-	GitHub github.GithubConfig
+// Config is the aggregation of eventing sources configurations.
+type Config struct {
+	GitHub github.Config
+}
+
+func (c *Config) Validate() *apis.FieldError {
+	return nil
 }

--- a/pkg/components/networking/config.go
+++ b/pkg/components/networking/config.go
@@ -14,18 +14,25 @@
  * limitations under the License.
  */
 
-package github
+package networking
 
 import (
 	"knative.dev/pkg/apis"
 	"knative.dev/reconciler-test/pkg/config"
 )
 
-// Config represents the github source configuration
+// Config is the Networking configuration
 type Config struct {
 	config.VersionSpec
+	Name string `desc:"the name of the networking layer"`
 }
 
 func (c *Config) Validate() *apis.FieldError {
-	return c.VersionSpec.Validate()
+	errs := c.VersionSpec.Validate()
+
+	// TODO: other networking layer
+	if c.Name != "kourier" {
+		errs = apis.ErrInvalidValue("c.Name", "name").Also(errs)
+	}
+	return errs
 }

--- a/pkg/components/networking/networking.go
+++ b/pkg/components/networking/networking.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"path"
+
+	"knative.dev/reconciler-test/pkg/release"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"knative.dev/reconciler-test/pkg/config"
+	"knative.dev/reconciler-test/pkg/framework"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+var (
+	Component = &networkingComponent{}
+
+	kourierRelease = release.Release{
+		Owner:      "knative-sandbox",
+		Repository: "net-kourier",
+		Artifacts:  []string{"kourier.yaml"},
+	}
+)
+
+type networkingComponent struct {
+}
+
+var _ framework.Component = (*networkingComponent)(nil)
+
+func (s *networkingComponent) QName() string {
+	return "components/networking"
+}
+
+func (s *networkingComponent) InstalledVersion(rc framework.ResourceContext) string {
+	// TODO: currently there is no way to know which version is installed.
+
+	var obj corev1.Namespace
+	_, err := rc.GetOrError("namespace", "kourier", &obj)
+
+	if err != nil {
+		return ""
+	}
+
+	return "devel"
+}
+
+func (s *networkingComponent) Install(rc framework.ResourceContext, gcfg config.Config) {
+	cfg, ok := gcfg.(*Config)
+	if !ok {
+		rc.Errorf("invalid configuration type for %s", s.QName())
+	}
+
+	if cfg.Version == "devel" {
+		rc.Apply(manifest.FromURL(path.Join(cfg.Path, "config")))
+		return
+	}
+
+	kourierRelease.Install(rc, cfg.Version)
+}

--- a/pkg/components/networking/specs.go
+++ b/pkg/components/networking/specs.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package networking
+
+// nodePortService is for running kourier in local machines (eg. kind)
+const nodePortService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier
+  namespace: kourier-system
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+spec:
+  ports:
+  - name: http2
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+    nodePort: 31080 
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+    nodePort: 31443
+  selector:
+    app: 3scale-kourier-gateway
+  type: NodePort`

--- a/pkg/components/sequencestepper/sequencestepper.go
+++ b/pkg/components/sequencestepper/sequencestepper.go
@@ -59,9 +59,8 @@ type sequenceStepperComponent struct {
 
 var _ framework.Component = (*sequenceStepperComponent)(nil)
 
-// Scope returns the component scope
-func (s *sequenceStepperComponent) Scope() framework.ComponentScope {
-	return framework.ComponentScopeResource
+func (s *sequenceStepperComponent) QName() string {
+	return "components/sqequencestepper"
 }
 
 func (s *sequenceStepperComponent) Required(rc framework.ResourceContext, cfg config.Config) {

--- a/pkg/components/serving/config.go
+++ b/pkg/components/serving/config.go
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package github
+package serving
 
 import (
 	"knative.dev/pkg/apis"
 	"knative.dev/reconciler-test/pkg/config"
 )
 
-// Config represents the github source configuration
+//  Config is the Serving configuration
 type Config struct {
 	config.VersionSpec
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -17,13 +17,18 @@
 package pkg
 
 import (
+	"knative.dev/pkg/apis"
 	"knative.dev/reconciler-test/pkg/components"
 	"knative.dev/reconciler-test/pkg/framework"
 )
 
-// Config aggregates all the known configuration parameters
-// Can be embedded by downstream projects.
+// AllConfig aggregates all the known configuration parameters
+// Can be embedded in downstream project configuration
 type AllConfig struct {
 	framework.BaseConfig
-	Components components.ComponentConfig
+	Components components.Config
+}
+
+func (c *AllConfig) Validate() *apis.FieldError {
+	return c.BaseConfig.Validate()
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"testing"
+
+	"knative.dev/pkg/apis"
 )
 
 type UpstreamStruct struct {
@@ -39,97 +41,63 @@ type downsstreamStruct struct {
 	Field2 string
 }
 
+func (*UpstreamStruct) Validate() *apis.FieldError {
+	return nil
+}
+
+func (*UpstreamStruct1) Validate() *apis.FieldError {
+	return nil
+}
+
+func (*UpstreamStruct2) Validate() *apis.FieldError {
+	return nil
+}
+
+func (*downsstreamStruct) Validate() *apis.FieldError {
+	return nil
+}
+
 func TestGetConfig(t *testing.T) {
+	v1 := downsstreamStruct{
+		UpstreamStruct: UpstreamStruct{},
+		Field2:         "value2",
+	}
+
+	v2 := downsstreamStruct{
+		UpstreamStruct: UpstreamStruct{},
+		Field2:         "value2",
+	}
+
+	v3 := downsstreamStruct{
+		UpstreamStruct: UpstreamStruct{
+			Field1: "value1",
+		},
+		Field2: "value2",
+	}
+
 	tests := []struct {
 		name     string
-		value    downsstreamStruct
+		value    Config
 		path     string
-		expected interface{}
+		expected Config
 	}{
 		{
-			name: "empty path",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{},
-				Field2:         "value2",
-			},
-			path: "",
-			expected: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{},
-				Field2:         "value2",
-			},
+			name:     "empty path",
+			value:    &v1,
+			path:     "",
+			expected: &v1,
 		},
 		{
-			name: "path to nothing",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{},
-				Field2:         "value2",
-			},
+			name:     "path to nothing",
+			value:    &v2,
 			path:     "path/to/nothing",
 			expected: nil,
 		},
 		{
-			name: "top-level field",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{},
-				Field2:         "value2",
-			},
-			path:     "field2",
-			expected: "value2",
-		},
-		{
-			name: "nested one level, anonymous",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{
-					Field1: "value1",
-				},
-				Field2: "value2",
-			},
-			path:     "field1",
-			expected: "value1",
-		},
-		{
-			name: "nested one level, return anonymous config",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{
-					Field1: "value1",
-				},
-				Field2: "value2",
-			},
-			path: "UpstreamStruct",
-			expected: UpstreamStruct{
-				Field1: "value1",
-			},
-		},
-		{
-			name: "nested two levels, not anonymous",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{
-					Field1: "value1",
-					Nested1: UpstreamStruct1{
-						Field1_1: "value3",
-					},
-				},
-				Field2: "value2",
-			},
-			path:     "nested1/field1_1",
-			expected: "value3",
-		},
-		{
-			name: "nested three levels, not anonymous, anonymous",
-			value: downsstreamStruct{
-				UpstreamStruct: UpstreamStruct{
-					Field1: "value1",
-					Nested1: UpstreamStruct1{
-						Field1_1: "value3",
-						UpstreamStruct2: UpstreamStruct2{
-							Field2_1: "value4",
-						},
-					},
-				},
-				Field2: "value2",
-			},
-			path:     "nested1/field2_1",
-			expected: "value4",
+			name:     "nested one level, return anonymous config",
+			value:    &v3,
+			path:     "UpstreamStruct",
+			expected: &v3.UpstreamStruct,
 		},
 	}
 
@@ -139,7 +107,7 @@ func TestGetConfig(t *testing.T) {
 			actual := GetConfig(tc.value, tc.path)
 
 			if actual != tc.expected {
-				t.Fatalf("expected %v, got %v", tc.expected, actual)
+				t.Fatalf("expected %+v, got %+v", tc.expected, actual)
 			}
 		})
 

--- a/pkg/config/test-config.yaml
+++ b/pkg/config/test-config.yaml
@@ -22,12 +22,14 @@ components:
   eventing:
     sources:
       github:
-        version: main # from source.
+        require: main # from source.
 
   serving:
-    core:
-      version: 0.17
-      network: istio
+    require: 0.17
+
+  networking:
+    name: istio
+    require: 0.17
+
   event.observer:
     target: log
-

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -32,6 +32,7 @@ type VersionSpec struct {
 	// ActualVersion is the version of the deployed component
 	ActualVersion string `flag:"-"`
 
+	// Parsed Required
 	vrange semver.Range `flag:"-"`
 }
 
@@ -60,7 +61,7 @@ func (spec *VersionSpec) Validate() *apis.FieldError {
 			return apis.ErrGeneric(fmt.Sprintf("mismatch required and resolved version (%s != %s)", spec.Version, spec.Require), "require", "version")
 
 		}
-		spec.Version = spec.Require
+		spec.Version = StripBuild(spec.Require)
 		return nil
 	}
 
@@ -117,4 +118,14 @@ func (spec *VersionSpec) Compare(version string) CompareType {
 	return CompareOutOfRange
 
 	return CompareEmptyVersion
+}
+
+// StripBuild returns version without build meta-data
+func StripBuild(version string) string {
+	v, err := semver.Parse(version)
+	if err != nil {
+		panic(err)
+	}
+	v.Build = nil
+	return v.String()
 }

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/blang/semver"
+)
+
+type VersionSpec struct {
+	Version string `desc:"the resolved version (only needed if require is a range)"`
+	Require string `desc:"the required version. Either a pin version, a version range or main"`
+	Path    string `desc:"the root location of the component source code"`
+
+	// ActualVersion is the version of the deployed component
+	ActualVersion string `flag:"-"`
+
+	vrange semver.Range `flag:"-"`
+}
+
+// Validate checks VersionSpec is correct
+func (spec *VersionSpec) Validate() *apis.FieldError {
+	if spec.Require == "" {
+		return apis.ErrMissingField("require")
+	}
+
+	if spec.Require == "main" {
+		if spec.Path == "" {
+			return apis.ErrMissingField("path")
+		}
+		return nil
+	}
+
+	r, err := semver.ParseRange(spec.Require)
+	if err != nil {
+		return apis.ErrInvalidValue(spec.Require, "require")
+	}
+	spec.vrange = r
+
+	_, err = semver.Parse(spec.Require)
+	if err == nil {
+		if spec.Version != "" && spec.Version != spec.Require {
+			return apis.ErrGeneric(fmt.Sprintf("mismatch required and resolved version (%s != %s)", spec.Version, spec.Require), "require", "version")
+
+		}
+		spec.Version = spec.Require
+		return nil
+	}
+
+	if spec.Version == "" {
+		// TODO: dynamic version resolution
+		return apis.ErrMissingField("version")
+	}
+
+	return nil
+}
+
+type CompareType int
+
+const (
+	// CompareDevel indicates both the resolved version and the compared version are "devel"
+	CompareDevel = CompareType(iota)
+
+	// CompareInvalidVersion indicates the compared version is invalid
+	CompareInvalidVersion
+
+	// CompareInRange indicates the compared version is in range of the required version
+	CompareInRange
+
+	// CompareOutOfRange indicates the compared version is not in the range of the required version
+	CompareOutOfRange
+
+	// CompareEmptyVersion indicates the compared version is empty
+	CompareEmptyVersion
+)
+
+// Compare compares version against the spec
+func (spec *VersionSpec) Compare(version string) CompareType {
+	spec.ActualVersion = version
+	if version == "" {
+		return CompareEmptyVersion
+	}
+
+	if version == "devel" {
+		if spec.Version == "devel" {
+			return CompareDevel
+		}
+		return CompareOutOfRange
+	}
+
+	v, err := semver.ParseTolerant(version)
+	if err != nil {
+		return CompareInvalidVersion
+	}
+
+	if spec.vrange(v) {
+		return CompareInRange
+	}
+
+	return CompareOutOfRange
+
+	return CompareEmptyVersion
+}

--- a/pkg/framework/component.go
+++ b/pkg/framework/component.go
@@ -16,22 +16,31 @@
 
 package framework
 
-import "knative.dev/reconciler-test/pkg/config"
-
-type ComponentScope string
-
-const (
-	ComponentScopeResource  = ComponentScope("resource")
-	ComponentScopeNamespace = ComponentScope("namespace")
-	ComponentScopeCluster   = ComponentScope("cluster")
+import (
+	"knative.dev/reconciler-test/pkg/config"
 )
 
 // Component is set of configuration files that can be installed
 // into a cluster
 type Component interface {
-	// Scope returns the component scope.
-	Scope() ComponentScope
+	// QName returns the fully qualified component name (e.g. components/eventing/sources/github)
+	QName() string
+}
 
-	// Required marks the component as being required.
-	Required(rc ResourceContext, cfg config.Config)
+type ClusterComponent interface {
+	Component
+
+	// InstalledVersion returns the installed version of the component.
+	// Return empty when the component is not installed
+	InstalledVersion(rc ResourceContext) string
+
+	// Install triggers the installation of the component
+	Install(rc ResourceContext, gcfg config.Config)
+}
+
+type ContainerComponent interface {
+	Component
+
+	// Required indicates this component will be used.
+	Required(rc ResourceContext, gcfg config.Config)
 }

--- a/pkg/framework/componentmanager.go
+++ b/pkg/framework/componentmanager.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package framework
+
+import (
+	"knative.dev/reconciler-test/pkg/config"
+)
+
+type ComponentManager struct {
+	components map[string]Component
+}
+
+func NewComponentManager() ComponentManager {
+	return ComponentManager{
+		components: make(map[string]Component),
+	}
+}
+
+// Required registers component is required.
+func (cm *ComponentManager) Required(rc ResourceContext, component Component, cfg config.Config) {
+	if _, ok := cm.components[component.QName()]; ok {
+		return
+	}
+
+	cm.components[component.QName()] = component
+	if cs, ok := component.(ClusterComponent); ok {
+		csrequired(rc, cs, cfg)
+	}
+
+	if cc, ok := component.(ContainerComponent); ok {
+		ccrequired(rc, cc, cfg)
+	}
+}
+
+func (cm *ComponentManager) Wait(rc ResourceContext) {
+	// TODO: wait for all components to be ready
+}
+
+func ccrequired(rc ResourceContext, component ContainerComponent, cfg config.Config) {
+	ccfg := config.GetConfig(cfg, component.QName())
+	if ccfg == nil {
+		rc.Errorf("☠️ missing %s configuration", component.QName())
+	}
+
+	if errs := ccfg.Validate(); errs != nil {
+		rc.Errorf("☠️ invalid configuration: %v", errs.ViaField(component.QName()))
+	}
+
+	component.Required(rc, ccfg.(config.Config))
+}
+
+func csrequired(rc ResourceContext, component ClusterComponent, cfg config.Config) {
+	ccfg := config.GetConfig(cfg, component.QName())
+	if ccfg == nil {
+		rc.Errorf("☠️ missing %s configuration", component.QName())
+	}
+
+	if errs := ccfg.Validate(); errs != nil {
+		rc.Errorf("☠️ invalid configuration %v", errs.ViaField(component.QName()))
+	}
+
+	vspec, ok := config.GetConfig(ccfg.(config.Config), "VersionSpec").(*config.VersionSpec)
+	if !ok {
+		rc.Errorf("☠️ component %s configuration does not embed config.VersionSpec", component.QName())
+	}
+
+	iv := component.InstalledVersion(rc)
+	diff := vspec.Compare(iv)
+
+	switch diff {
+	case config.CompareInRange:
+		rc.Logf("✅ component %s@%v already installed (required %v)", component.QName(), vspec.ActualVersion, vspec.Require)
+	case config.CompareDevel:
+		rc.Logf("🏃 installing component %s from source code", component.QName())
+		component.Install(rc, ccfg.(config.Config))
+	case config.CompareOutOfRange:
+		rc.Errorf("☠️ installed component %s@%s does not match required version @%s", component.QName(), vspec.ActualVersion, vspec.Version)
+	case config.CompareInvalidVersion:
+		rc.Errorf("️️☠️ invalid version %s", iv)
+	case config.CompareEmptyVersion:
+		rc.Logf("🏃 installing component %s@%s", component.QName(), vspec.Version)
+		component.Install(rc, ccfg.(config.Config))
+	}
+}

--- a/pkg/framework/config.go
+++ b/pkg/framework/config.go
@@ -16,6 +16,8 @@
 
 package framework
 
+import "knative.dev/pkg/apis"
+
 // BaseConfig defines the configuration parameters
 // controlling the framework behavior.
 type BaseConfig struct {
@@ -30,4 +32,8 @@ type Requirements struct {
 	Must   bool `desc:"run test mark as Must. Default is true"`
 	Should bool `desc:"run test mark as Should. Default is true"`
 	May    bool `desc:"run test mark as May. Default is true"`
+}
+
+func (c *BaseConfig) Validate() *apis.FieldError {
+	return nil
 }

--- a/pkg/framework/resourcecontext.go
+++ b/pkg/framework/resourcecontext.go
@@ -125,6 +125,15 @@ type ResourceContext interface {
 	CreateFromURIOrFail(uri string, recursive bool)
 }
 
+// --- Constructors
+
+func NewResourceContext(parent ResourceContext, namespace string) ResourceContext {
+	return &resourceContextImpl{
+		context:   parent,
+		namespace: namespace,
+	}
+}
+
 // --- Default implementation
 
 type resourceContextImpl struct {
@@ -175,7 +184,7 @@ func (c *resourceContextImpl) ApplyOrError(provider manifest.Provider, data ...i
 		flags = append(flags, "-n", c.namespace)
 	}
 
-	c.Logf("running ko apply -f %s %s", path, strings.Join(flags, " "))
+	c.Logf("🏃 running ko apply -f %s %s", path, strings.Join(flags, " "))
 	o, err := installer.KoApply(path, flags...)
 	if err != nil {
 		// We care about the command output more than the exit code
@@ -209,7 +218,7 @@ func (c *resourceContextImpl) DeleteOrError(provider manifest.Provider, data ...
 		flags = append(flags, "-n", c.namespace)
 	}
 
-	c.Logf("running ko delete -f %s %s", path, strings.Join(flags, " "))
+	c.Logf("🏃 running ko delete -f %s %s", path, strings.Join(flags, " "))
 	o, err := installer.KoDelete(path, flags...)
 	if err != nil {
 		// We care about the command output more than the exit code

--- a/pkg/framework/testcontext.go
+++ b/pkg/framework/testcontext.go
@@ -44,6 +44,18 @@ type TestContext interface {
 	gomega.Gomega
 }
 
+// --- Constructors
+
+func NewTestContext(parent TestContext, namespace string) TestContext {
+	impl := parent.(*testContextImpl)
+
+	return &testContextImpl{
+		resourceContextImpl: impl.resourceContextImpl,
+		t:                   impl.t,
+		WithT:               impl.WithT,
+	}
+}
+
 // --- Default implementation
 
 type testContextImpl struct {

--- a/pkg/installer/kubectl.go
+++ b/pkg/installer/kubectl.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-// Use ko to get a resource
+// Use kubectl to get a resource
 func KubectlGet(resource, name string, flags ...string) (string, error) {
 	extra := ""
 	if len(flags) > 0 {
@@ -28,6 +28,20 @@ func KubectlGet(resource, name string, flags ...string) (string, error) {
 	}
 
 	out, err := runCmd(fmt.Sprintf("kubectl get %s %s%s -oyaml", resource, name, extra))
+	if err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// Use kubectl to patch a resource
+func KubectlPatch(resource, name string, flags ...string) (string, error) {
+	extra := ""
+	if len(flags) > 0 {
+		extra = " " + strings.Join(flags, " ")
+	}
+
+	out, err := runCmd(fmt.Sprintf("kubectl patch %s %s%s -oyaml", resource, name, extra))
 	if err != nil {
 		return out, err
 	}

--- a/pkg/manifest/urlprovider.go
+++ b/pkg/manifest/urlprovider.go
@@ -17,6 +17,7 @@
 package manifest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,6 +39,15 @@ func (p *urlProvider) GetPath() (string, error) {
 		}
 		defer resp.Body.Close()
 
+		buffer, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("%d %s", resp.StatusCode, buffer)
+		}
+
 		u, _ := url.Parse(p.url) // no error (see isURL)
 		stem := strings.TrimRight(path.Base(u.Path), ".yaml")
 
@@ -46,11 +56,6 @@ func (p *urlProvider) GetPath() (string, error) {
 			return "", err
 		}
 		defer f.Close()
-
-		buffer, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return "", err
-		}
 
 		_, err = f.Write(buffer)
 		if err != nil {

--- a/pkg/release/installer.go
+++ b/pkg/release/installer.go
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package github
+package release
 
 import (
-	"knative.dev/pkg/apis"
-	"knative.dev/reconciler-test/pkg/config"
+	"fmt"
+
+	"knative.dev/reconciler-test/pkg/framework"
+	"knative.dev/reconciler-test/pkg/manifest"
 )
 
-// Config represents the github source configuration
-type Config struct {
-	config.VersionSpec
-}
+func (r Release) Install(rc framework.ResourceContext, version string) {
+	baseArtifactURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/v%s/", r.Owner, r.Repository, version)
 
-func (c *Config) Validate() *apis.FieldError {
-	return c.VersionSpec.Validate()
+	for _, artifact := range r.Artifacts {
+		rc.Apply(manifest.FromURL(fmt.Sprintf("%s/%s", baseArtifactURL, artifact)))
+	}
 }

--- a/pkg/release/interface.go
+++ b/pkg/release/interface.go
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package release
 
-package github
-
-import (
-	"knative.dev/pkg/apis"
-	"knative.dev/reconciler-test/pkg/config"
-)
-
-// Config represents the github source configuration
-type Config struct {
-	config.VersionSpec
-}
-
-func (c *Config) Validate() *apis.FieldError {
-	return c.VersionSpec.Validate()
+type Release struct {
+	Owner      string
+	Repository string
+	Artifacts  []string
 }

--- a/test/sample/github/suite_test.go
+++ b/test/sample/github/suite_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
  * Copyright 2020 The Knative Authors
  *
@@ -17,15 +19,23 @@
 package github
 
 import (
-	"knative.dev/pkg/apis"
-	"knative.dev/reconciler-test/pkg/config"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg"
+	"knative.dev/reconciler-test/pkg/components/eventing/sources/github"
+	"knative.dev/reconciler-test/pkg/components/networking"
+	"knative.dev/reconciler-test/pkg/components/serving"
+	"knative.dev/reconciler-test/pkg/framework"
 )
 
-// Config represents the github source configuration
-type Config struct {
-	config.VersionSpec
-}
+var myconfig = pkg.AllConfig{}
 
-func (c *Config) Validate() *apis.FieldError {
-	return c.VersionSpec.Validate()
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		Configure(&myconfig).
+		Require(serving.Component).
+		Require(networking.Component).
+		Require(github.Component).
+		Run()
 }

--- a/test/sample/github/test-config.yaml
+++ b/test/sample/github/test-config.yaml
@@ -1,0 +1,18 @@
+components:
+  serving:
+    require: ">0.15.x"
+    version: 0.18.0
+
+  networking:
+    name: kourier
+    require: ">0.15.x"
+    version: 0.18.0
+
+  eventing:
+    sources:
+      github:
+        # The required version (a pin version, a version range or devel)
+        require: 0.17.x
+
+        # The resolved version (mandatory)
+        version: 0.17.0

--- a/test/sample/test-config.yaml
+++ b/test/sample/test-config.yaml
@@ -1,7 +1,1 @@
 broker: kafka
-
-components:
-  eventing:
-    sources:
-      github:
-        version: 0.17.0


### PR DESCRIPTION
- Harden a bit the GithubSource component and add Serving and Networking (only Kourier at the moment).
- Add proposal defining what constitute a conformant cluster wrt test suite requirements (see VersionSpec). 
- Externalize component lifecycle management. Components are now easier to implements. Only for Cluster Scope component for now.