### PR TITLE
conformance lib poc

### DIFF
--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -61,7 +61,9 @@ import (
 // To run your tests with T you can setup it as follows:
 //
 //   func TestConformance(t *testing.T) {
-//     myT := test.New(MyT{}, t)
+//     myT := MyT{}
+//     test.Init(MyT{}, t)
+//
 //     myT.Stable("some feature", TestFeature)
 //   }
 //

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"reflect"
+	"testing"
+
+	"knative.dev/pkg/test/helpers"
+	"knative.dev/reconciler-test/pkg/test/feature"
+	"knative.dev/reconciler-test/pkg/test/requirement"
+)
+
+// Context interface defines the methods required by a test context
+type Context interface {
+	// Copy should return a copy of the existing context
+	Copy() Context
+
+	// Setup should initialize the context with a test
+	//
+	// Note: implementations shouldn't need to implement this
+	// if they embed a BaseContext struct
+	Setup(c Context, t *testing.T)
+}
+
+// BaseContext extends testing.T with additional behaviour
+// to test various requirement levels & feature states
+type BaseContext struct {
+	*testing.T
+
+	RequirementLevels requirement.Levels
+	FeatureStates     feature.States
+
+	// Implemention note:
+	//
+	// To make authoring tests easier we want to support
+	// tests invocations
+	//
+	// ctx := SomeTestContext{...}
+	// ctx.Alpha("name", func(ctx *SomeTestContext) {...})
+	//
+	// This helps avoid excessive casting in downstream tests
+	c Context
+}
+
+var _ Context = (*BaseContext)(nil)
+
+// Setup implements the Context interface
+func (b *BaseContext) Setup(c Context, t *testing.T) {
+	b.c = c
+	b.T = t
+}
+
+// Copy implements the Context interface
+func (b *BaseContext) Copy() Context {
+	cpy := *b
+	return &cpy
+}
+
+// Must invokes f as a subtest if the context has the requirement level MUST
+func (b *BaseContext) Must(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeLevel(requirement.Must, name, f)
+}
+
+// MustNot invokes f as a subtest only if the context has the requirement level MUST NOT
+func (b *BaseContext) MustNot(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeLevel(requirement.MustNot, name, f)
+}
+
+// Should invokes f as a subtest only if the context has the requirement level SHOULD
+func (b *BaseContext) Should(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeLevel(requirement.Should, name, f)
+}
+
+// ShouldNot invokes f as a subtest only if the context has the requirement level SHOULD NOT
+func (b *BaseContext) ShouldNot(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeLevel(requirement.ShouldNot, name, f)
+}
+
+// May invokes f as a subtest only if the context has the requirement level MAY
+func (b *BaseContext) May(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeLevel(requirement.May, name, f)
+}
+
+// Alpha invokes f as a subtest only if the context has the 'Alpha' feature state enabled
+func (b *BaseContext) Alpha(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeFeature(feature.Alpha, name, f)
+}
+
+// Beta invokes f as a subtest only if the context has the 'Beta' feature state enabled
+func (b *BaseContext) Beta(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeFeature(feature.Beta, name, f)
+}
+
+// Stable invokes f as a subtest only if the context has the 'Stable' feature state enabled
+func (b *BaseContext) Stable(name string, f interface{}) bool {
+	b.Helper()
+	return b.invokeFeature(feature.Stable, name, f)
+}
+
+// ObjectNameForTest returns a unique resource name based on the test name
+func (b *BaseContext) ObjectNameForTest() string {
+	return helpers.ObjectNameForTest(b.T)
+}
+
+// Run invokes f as a subtest
+func (b *BaseContext) Run(name string, f interface{}) bool {
+	b.Helper()
+	b.validateCallback(f)
+
+	return b.T.Run(name, func(t *testing.T) {
+		b.invoke(f, t)
+	})
+}
+
+func (b *BaseContext) invokeFeature(state feature.States, name string, f interface{}) bool {
+	b.Helper()
+	b.validateCallback(f)
+
+	return b.T.Run(name, func(t *testing.T) {
+		if b.FeatureStates&state == 0 {
+			t.Skipf("%s features not enabled for testing", state)
+		}
+		b.invoke(f, t)
+	})
+}
+
+func (b *BaseContext) invokeLevel(levels requirement.Levels, name string, f interface{}) bool {
+	b.Helper()
+	b.validateCallback(f)
+
+	return b.T.Run(name, func(t *testing.T) {
+		if b.RequirementLevels&levels == 0 {
+			t.Skipf("%s requirement not enabled for testing", levels)
+		}
+
+		b.invoke(f, t)
+	})
+}
+
+func (b *BaseContext) invoke(f interface{}, t *testing.T) {
+	newCtx := b.c.Copy()
+	newCtx.Setup(newCtx, t)
+
+	in := []reflect.Value{reflect.ValueOf(newCtx)}
+	reflect.ValueOf(f).Call(in)
+}
+
+func (b *BaseContext) validateCallback(f interface{}) {
+	b.Helper()
+
+	if f == nil {
+		b.Fatal("callback should not be nil")
+	}
+
+	fType := reflect.TypeOf(f)
+	if fType.Kind() != reflect.Func {
+		b.Fatal("callback should be a function")
+	}
+
+	contextType := reflect.TypeOf(b.c)
+
+	if fType.NumIn() != 1 || fType.In(0) != contextType {
+		b.Fatalf("callback should take a single argument of %v", contextType)
+	}
+}

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 
@@ -69,6 +70,23 @@ func (b *BaseContext) Setup(c Context, t *testing.T) {
 func (b *BaseContext) Copy() Context {
 	cpy := *b
 	return &cpy
+}
+
+// AddFlags adds requirement and feature state flags to the FlagSet.
+// The flagset will modify this context instance
+//
+// Calling AddFlags will also default the requirement level and
+// feature states to test everything
+func (b *BaseContext) AddFlags(fs *flag.FlagSet) {
+	if b.RequirementLevels == 0 {
+		b.RequirementLevels = requirement.All
+	}
+	if b.FeatureStates == 0 {
+		b.FeatureStates = feature.All
+	}
+
+	b.RequirementLevels.AddFlags(fs)
+	b.FeatureStates.AddFlags(fs)
 }
 
 // Must invokes f as a subtest if the context has the requirement level MUST

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/test/feature"
+	"knative.dev/reconciler-test/pkg/test/requirement"
+)
+
+type mockContext struct {
+	BaseContext
+}
+
+func (c *mockContext) Copy() Context {
+	return c
+}
+
+func TestRunInvocation(t *testing.T) {
+	ctx := &mockContext{}
+	ctx.Setup(ctx, t)
+
+	invoked := false
+	ctx.Run("subtest", func(m *mockContext) {
+		invoked = true
+	})
+
+	if !invoked {
+		t.Error("Run() did not invoke the subtest")
+	}
+}
+
+func TestLevelInvocation(t *testing.T) {
+	cases := []struct {
+		name  string
+		level requirement.Levels
+		f     func(*mockContext, string, interface{}) bool
+	}{
+		{"Must", requirement.Must, (*mockContext).Must},
+		{"MustNot", requirement.MustNot, (*mockContext).MustNot},
+		{"Should", requirement.Should, (*mockContext).Should},
+		{"ShouldNot", requirement.ShouldNot, (*mockContext).ShouldNot},
+		{"May", requirement.May, (*mockContext).May},
+
+		{"Must", requirement.All, (*mockContext).Must},
+		{"MustNot", requirement.All, (*mockContext).MustNot},
+		{"Should", requirement.All, (*mockContext).Should},
+		{"ShouldNot", requirement.All, (*mockContext).ShouldNot},
+		{"May", requirement.All, (*mockContext).May},
+	}
+
+	for _, c := range cases {
+		t.Run(c.level.String(), func(t *testing.T) {
+			ctx := &mockContext{}
+			ctx.Setup(ctx, t)
+			ctx.RequirementLevels = c.level
+
+			invoked := false
+			c.f(ctx, "subtest", func(m *mockContext) {
+				invoked = true
+			})
+
+			if !invoked {
+				t.Errorf("level %s did not invoke %s", c.level, c.name)
+			}
+		})
+	}
+}
+
+func TestStateInvocation(t *testing.T) {
+	cases := []struct {
+		name  string
+		state feature.States
+		f     func(*mockContext, string, interface{}) bool
+	}{
+		{"Alpha", feature.Alpha, (*mockContext).Alpha},
+		{"Beta", feature.Beta, (*mockContext).Beta},
+		{"Stable", feature.Stable, (*mockContext).Stable},
+
+		{"Alpha", feature.All, (*mockContext).Alpha},
+		{"Beta", feature.All, (*mockContext).Beta},
+		{"Stable", feature.All, (*mockContext).Stable},
+	}
+
+	for _, c := range cases {
+		t.Run(c.state.String(), func(t *testing.T) {
+			ctx := &mockContext{}
+			ctx.Setup(ctx, t)
+			ctx.FeatureStates = c.state
+
+			invoked := false
+			c.f(ctx, "subtest", func(m *mockContext) {
+				invoked = true
+			})
+
+			if !invoked {
+				t.Errorf("state %s did not invoke %s", c.state, c.name)
+			}
+		})
+	}
+}
+
+func TestBadCallback(t *testing.T) {
+	if os.Getenv("CRASH") == "1" {
+		t.Run("nil", func(t *testing.T) {
+			ctx := &mockContext{}
+			ctx.Setup(ctx, t)
+			ctx.Run("subtest", nil)
+		})
+
+		t.Run("non-func", func(t *testing.T) {
+			ctx := &mockContext{}
+			ctx.Setup(ctx, t)
+			ctx.Run("subtest", 1)
+		})
+
+		t.Run("bad-type", func(t *testing.T) {
+			ctx := &mockContext{}
+			ctx.Setup(ctx, t)
+			ctx.Run("subtest", func(int) {})
+		})
+		return
+	}
+
+	for _, test := range []string{"nil", "non-func", "bad-type"} {
+		t.Run(test, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestBadCallback/"+test)
+			cmd.Env = append(os.Environ(), "CRASH=1")
+			err := cmd.Run()
+			if e, ok := err.(*exec.ExitError); ok && e.ExitCode() == 1 {
+				return
+			}
+			// Anything but an exit code 1 is abnormal
+			// ie. 2 = something paniced
+			t.Fatalf("process ran with err %v, want exit status 1", err)
+		})
+	}
+}

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"flag"
 	"os"
 	"os/exec"
 	"testing"
@@ -31,6 +32,25 @@ type mockContext struct {
 
 func (c *mockContext) Copy() Context {
 	return c
+}
+
+func TestFlags(t *testing.T) {
+	ctx := mockContext{}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	ctx.AddFlags(fs)
+
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal("failed to parse", err)
+	}
+
+	if got, want := ctx.RequirementLevels, requirement.All; got != want {
+		t.Errorf("wrong requirement level - got: %s want: %s", got, want)
+	}
+
+	if got, want := ctx.FeatureStates, feature.All; got != want {
+		t.Errorf("wrong requirement level - got: %s want: %s", got, want)
+	}
 }
 
 func TestRunInvocation(t *testing.T) {

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package test_test
 
 import (
 	"flag"
@@ -22,11 +22,14 @@ import (
 	"os/exec"
 	"testing"
 
+	"knative.dev/reconciler-test/pkg/test"
 	"knative.dev/reconciler-test/pkg/test/feature"
 	"knative.dev/reconciler-test/pkg/test/requirement"
 )
 
-type mockContext struct{ T }
+type mockContext struct {
+	test.T
+}
 
 func TestFlags(t *testing.T) {
 	ctx := mockContext{}
@@ -49,7 +52,7 @@ func TestFlags(t *testing.T) {
 
 func TestRunInvocation(t *testing.T) {
 	ctx := &mockContext{}
-	Init(ctx, t)
+	test.Init(ctx, t)
 
 	invoked := false
 	ctx.Run("subtest", func(m *mockContext) {
@@ -83,7 +86,7 @@ func TestLevelInvocation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.level.String(), func(t *testing.T) {
 			ctx := &mockContext{}
-			Init(ctx, t)
+			test.Init(ctx, t)
 
 			invoked := false
 			subtest := func(m *mockContext) { invoked = true }
@@ -123,7 +126,7 @@ func TestStateInvocation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.state.String(), func(t *testing.T) {
 			ctx := &mockContext{}
-			Init(ctx, t)
+			test.Init(ctx, t)
 
 			invoked := false
 			subtest := func(m *mockContext) { invoked = true }
@@ -149,19 +152,19 @@ func TestBadCallback(t *testing.T) {
 	if os.Getenv("CRASH") == "1" {
 		t.Run("nil", func(t *testing.T) {
 			ctx := &mockContext{}
-			Init(ctx, t)
+			test.Init(ctx, t)
 			ctx.Run("subtest", nil)
 		})
 
 		t.Run("non-func", func(t *testing.T) {
 			ctx := &mockContext{}
-			Init(ctx, t)
+			test.Init(ctx, t)
 			ctx.Run("subtest", 1)
 		})
 
 		t.Run("bad-type", func(t *testing.T) {
 			ctx := &mockContext{}
-			Init(ctx, t)
+			test.Init(ctx, t)
 			ctx.Run("subtest", func(int) {})
 		})
 		return
@@ -187,26 +190,26 @@ type noEmbeddedT struct{}
 func TestBadInitParam(t *testing.T) {
 	defer func() {
 		if err := recover(); err == nil {
-			t.Error("Init should panic when passed a type that doesn't embed test.T")
+			t.Error("test.Init should panic when passed a type that doesn't embed test.T")
 		}
 	}()
-	Init(noEmbeddedT{}, t)
+	test.Init(noEmbeddedT{}, t)
 }
 
 type customSetup struct {
-	T
-	test *testing.T
+	test.T
+	setupArg *testing.T
 }
 
 func (c *customSetup) Setup(t *testing.T) {
-	c.test = t
+	c.setupArg = t
 }
 
 func TestCustomSetup(t *testing.T) {
 	cs := &customSetup{}
-	Init(cs, t)
+	test.Init(cs, t)
 
-	if cs.test != t {
+	if cs.setupArg != t {
 		t.Error("expected Setup to be called")
 	}
 }

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 type mockContext struct {
-	BaseContext
+	T
 }
 
-func (c *mockContext) Copy() Context {
+func (c *mockContext) Copy() C {
 	return c
 }
 

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -26,13 +26,7 @@ import (
 	"knative.dev/reconciler-test/pkg/test/requirement"
 )
 
-type mockContext struct {
-	T
-}
-
-func (c *mockContext) Copy() C {
-	return c
-}
+type mockContext struct{ T }
 
 func TestFlags(t *testing.T) {
 	ctx := mockContext{}
@@ -190,8 +184,6 @@ func TestBadCallback(t *testing.T) {
 
 type noEmbeddedT struct{}
 
-func (n noEmbeddedT) Copy() C { return n }
-
 func TestBadInitParam(t *testing.T) {
 	defer func() {
 		if err := recover(); err == nil {
@@ -206,7 +198,6 @@ type customSetup struct {
 	test *testing.T
 }
 
-func (c *customSetup) Copy() C { return c }
 func (c *customSetup) Setup(t *testing.T) {
 	c.test = t
 }

--- a/pkg/test/environment/cluster.go
+++ b/pkg/test/environment/cluster.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package environment
+
+import (
+	"flag"
+	"os"
+	"os/user"
+	"path"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type Cluster struct {
+	Name       string // K8s cluster (defaults to cluster in kubeconfig)
+	KubeConfig string // Path to kubeconfig (defaults to ./kube/config)
+	Namespace  string // K8s namespace (blank by default, to be overwritten by test suite)
+}
+
+func (s *Cluster) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&s.Name, "env.cluster.name", "",
+		"Provide the cluster to test against. Defaults to the current cluster in kubeconfig.")
+
+	// Use KUBECONFIG if available
+	defaultKubeconfig := os.Getenv("KUBECONFIG")
+
+	// If KUBECONFIG env var isn't set then look for $HOME/.kube/config
+	if defaultKubeconfig == "" {
+		if usr, err := user.Current(); err == nil {
+			defaultKubeconfig = path.Join(usr.HomeDir, ".kube/config")
+		}
+	}
+
+	// Allow for --kubeconfig on the cmd line to override the above logic
+	fs.StringVar(&s.KubeConfig, "env.cluster.kubeconfig", defaultKubeconfig,
+		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")
+
+	fs.StringVar(&s.Namespace, "env.cluster.namespace", "",
+		"Provide the namespace you would like to use for these tests.")
+}
+
+func (c *Cluster) ClientConfig() *rest.Config {
+	overrides := &clientcmd.ConfigOverrides{}
+	overrides.Context.Cluster = c.Name
+
+	loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: c.KubeConfig}
+
+	conf, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides).ClientConfig()
+	if err != nil {
+		panic(err)
+	}
+	return conf
+}

--- a/pkg/test/environment/cluster.go
+++ b/pkg/test/environment/cluster.go
@@ -30,7 +30,6 @@ import (
 type Cluster struct {
 	Name       string // K8s cluster (defaults to cluster in kubeconfig)
 	KubeConfig string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace  string // K8s namespace (blank by default, to be overwritten by test suite)
 }
 
 func (s *Cluster) AddFlags(fs *flag.FlagSet) {
@@ -50,9 +49,6 @@ func (s *Cluster) AddFlags(fs *flag.FlagSet) {
 	// Allow for --kubeconfig on the cmd line to override the above logic
 	fs.StringVar(&s.KubeConfig, "env.cluster.kubeconfig", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")
-
-	fs.StringVar(&s.Namespace, "env.cluster.namespace", "",
-		"Provide the namespace you would like to use for these tests.")
 }
 
 func (c *Cluster) ClientConfig() *rest.Config {

--- a/pkg/test/environment/images.go
+++ b/pkg/test/environment/images.go
@@ -40,7 +40,7 @@ func (i *Images) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&i.Tag, "env.image.tag", "latest", "Provide the version tag for the test images.")
 }
 
-func (i *Images) ImagePath(name string) string {
+func (i *Images) Path(name string) string {
 	tpl, err := template.New("image").Parse(i.Template)
 	if err != nil {
 		panic("could not parse image template: " + err.Error())

--- a/pkg/test/environment/images.go
+++ b/pkg/test/environment/images.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package environment
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"text/template"
+)
+
+type Images struct {
+	Template   string // Template to build the image reference (defaults to {{.Repository}}/{{.Name}}:{{.Tag}})
+	Repository string // Image repository (defaults to $KO_DOCKER_REPO)
+	Tag        string // Tag for test images
+}
+
+func (i *Images) AddFlags(fs *flag.FlagSet) {
+	defaultRepo := os.Getenv("KO_DOCKER_REPO")
+	fs.StringVar(&i.Repository, "env.image.repo", defaultRepo,
+		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $KO_DOCKER_REPO")
+
+	fs.StringVar(&i.Template, "env.image.template", "{{.Repository}}/{{.Name}}:{{.Tag}}",
+		"Provide a template to generate the reference to an image from the test. Defaults to `{{.Repository}}/{{.Name}}:{{.Tag}}`.")
+
+	fs.StringVar(&i.Tag, "env.image.tag", "latest", "Provide the version tag for the test images.")
+}
+
+func (i *Images) ImagePath(name string) string {
+	tpl, err := template.New("image").Parse(i.Template)
+	if err != nil {
+		panic("could not parse image template: " + err.Error())
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, struct {
+		Repository string
+		Name       string
+		Tag        string
+	}{
+		Repository: i.Repository,
+		Name:       name,
+		Tag:        i.Tag,
+	}); err != nil {
+		panic("could not apply the image template: " + err.Error())
+	}
+	return buf.String()
+}

--- a/pkg/test/environment/ingress.go
+++ b/pkg/test/environment/ingress.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package environment
+
+import "flag"
+
+type Ingress struct {
+	EndpointOverride string // Host to use for overriding the endpoint
+	Name             string // K8s Service name acting as an ingress
+	Namespace        string // K8s Service namespace acting as an ingress
+}
+
+func (i *Ingress) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&i.EndpointOverride, "env.ingress.endpoint", "",
+		"Provide a static endpoint url to the ingress server used during tests.")
+
+	fs.StringVar(&i.Name, "env.ingress.name", "",
+		"Provide a k8s service name as a target ingress used during tests.")
+
+	fs.StringVar(&i.Namespace, "env.ingress.namespace", "",
+		"Provide a k8s service namespace as a target ingress used during tests.")
+}

--- a/pkg/test/environment/spoof.go
+++ b/pkg/test/environment/spoof.go
@@ -21,12 +21,12 @@ import (
 	"time"
 )
 
-type Spoofing struct {
+type Spoof struct {
 	RequestInterval time.Duration // SpoofRequestInterval is the interval between requests in SpoofingClient
 	RequestTimeout  time.Duration // SpoofRequestTimeout is the timeout for polling requests in SpoofingClient
 }
 
-func (s *Spoofing) AddFlags(fs *flag.FlagSet) {
+func (s *Spoof) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&s.RequestInterval, "env.spoof.interval", 1*time.Second,
 		"Provide an interval between requests for the SpoofingClient")
 

--- a/pkg/test/environment/spoof.go
+++ b/pkg/test/environment/spoof.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package environment
+
+import (
+	"flag"
+	"time"
+)
+
+type Spoofing struct {
+	RequestInterval time.Duration // SpoofRequestInterval is the interval between requests in SpoofingClient
+	RequestTimeout  time.Duration // SpoofRequestTimeout is the timeout for polling requests in SpoofingClient
+}
+
+func (s *Spoofing) AddFlags(fs *flag.FlagSet) {
+	fs.DurationVar(&s.RequestInterval, "env.spoof.interval", 1*time.Second,
+		"Provide an interval between requests for the SpoofingClient")
+
+	fs.DurationVar(&s.RequestTimeout, "env.spoof.timeout", 5*time.Minute,
+		"Provide a request timeout for the SpoofingClient")
+}

--- a/pkg/test/feature/states.go
+++ b/pkg/test/feature/states.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type States uint8
+
+const (
+	// Alpha implies a feature is experimental and may change
+	Alpha States = 1 << iota
+
+	// Beta implies a feature is complete but may have unknown bugs or issues
+	Beta
+
+	// Stable implies a feature is ready for production
+	Stable
+
+	// All flag enables all feature states
+	All = Alpha | Beta | Stable
+)
+
+func (s States) String() string {
+	if s == All {
+		return "ALL STATES"
+	}
+
+	var b strings.Builder
+
+	for _, entry := range mapping {
+		if s&entry.state == 0 {
+			continue
+		}
+
+		if b.Len() != 0 {
+			b.WriteString("|")
+		}
+
+		b.WriteString(entry.name)
+	}
+
+	return b.String()
+}
+
+func (s *States) AddFlags(fs *flag.FlagSet) {
+	for _, entry := range mapping {
+		flagName := "feature." + strings.ReplaceAll(strings.ToLower(entry.name), " ", "")
+		usage := fmt.Sprintf("toggles %q feature assertions", entry.name)
+		fs.Var(stateValue{entry.state, s}, flagName, usage)
+	}
+
+	fs.Var(stateValue{All, s}, "feature.all", "toggles all features")
+}
+
+type stateValue struct {
+	mask  States
+	value *States
+}
+
+func (sv stateValue) Get() interface{} {
+	return *sv.value & sv.mask
+}
+
+func (sv stateValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+
+	if v {
+		*sv.value = *sv.value | sv.mask // set
+	} else {
+		*sv.value = *sv.value &^ sv.mask // clear
+	}
+
+	return nil
+}
+
+func (sv stateValue) IsBoolFlag() bool {
+	return true
+}
+
+func (sv stateValue) String() string {
+	if sv.value != nil && sv.mask&*sv.value != 0 {
+		return "true"
+	}
+
+	return "false"
+}
+
+var mapping = [...]struct {
+	state States
+	name  string
+}{
+	{Alpha, "Alpha"},
+	{Beta, "Beta"},
+	{Stable, "Stable"},
+}

--- a/pkg/test/feature/states_test.go
+++ b/pkg/test/feature/states_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"flag"
+	"io/ioutil"
+	"testing"
+)
+
+var cases = []struct {
+	state States
+	flag  string
+}{
+	{Alpha, "-feature.alpha"},
+	{Beta, "-feature.beta"},
+	{Stable, "-feature.stable"},
+}
+
+func TestTurnOn(t *testing.T) {
+	for _, tc := range cases {
+		var l States
+
+		fs := &flag.FlagSet{}
+		fs.SetOutput(ioutil.Discard)
+		l.AddFlags(fs)
+
+		if err := fs.Parse([]string{tc.flag}); err != nil {
+			t.Fatal(err)
+		}
+
+		if l&tc.state == 0 {
+			t.Errorf("flag %q did not enable %s", tc.flag, tc.state)
+		}
+	}
+}
+
+func TestTurnOff(t *testing.T) {
+	for _, tc := range cases {
+		l := ^States(0)
+
+		fs := &flag.FlagSet{}
+		fs.SetOutput(ioutil.Discard)
+		l.AddFlags(fs)
+
+		if err := fs.Parse([]string{tc.flag + "=false"}); err != nil {
+			t.Fatal(err)
+		}
+
+		if l&tc.state != 0 {
+			t.Errorf("flag %q did not disable %s", tc.flag, tc.state)
+		}
+	}
+}

--- a/pkg/test/requirement/level.go
+++ b/pkg/test/requirement/level.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirement
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Levels uint8
+
+const (
+	// Must means that the definition is an absolute requirement of the specification.
+	Must Levels = 1 << iota
+
+	// MustNot means that the definition is an absolute prohibition of the specification.
+	MustNot
+
+	// Should means that there may exist valid reasons in particular circumstances to
+	// ignore a particular item
+	Should
+
+	// Should means that there may exist valid reasons in particular circumstances when the
+	// particular behavior is acceptable or even useful
+	ShouldNot
+
+	// May means that an item is truly optional
+	May
+
+	// TODO(dprotaso) Do we want these aliases?
+	// // Required means that the definition is an absolute requirement of the specification.
+	// Required = Must
+
+	// // Shall means that the definition is an absolute requirement of the specification.
+	// Shall = Must
+
+	// // ShallNot means that the definition is an absolute prohibition of the specification.
+	// ShallNot = MustNot
+
+	// // Recommended means that there may exist valid reasons in particular circumstances to
+	// // ignore a particular item
+	// Recommended = Should
+
+	// // NotRecommended means that there may exist valid reasons in particular circumstances when the
+	// // particular behavior is acceptable or even useful
+	// NotRecommended = ShouldNot
+
+	// All flag enables all requirement levels
+	All = Must | MustNot | Should | ShouldNot | May
+)
+
+func (l Levels) String() string {
+	if l == All {
+		return "ALL_LEVELS"
+	}
+
+	var b strings.Builder
+
+	for _, entry := range mapping {
+		if l&entry.level == 0 {
+			continue
+		}
+
+		if b.Len() != 0 {
+			b.WriteString("|")
+		}
+
+		b.WriteString(entry.name)
+	}
+
+	return b.String()
+}
+
+func (l *Levels) AddFlags(fs *flag.FlagSet) {
+	for _, entry := range mapping {
+		flagName := "requirement." + strings.ReplaceAll(strings.ToLower(entry.name), " ", "")
+		usage := fmt.Sprintf("toggles %q requirement assertions", entry.name)
+		fs.Var(levelValue{entry.level, l}, flagName, usage)
+	}
+
+	fs.Var(levelValue{All, l}, "requirement.all", "toggles all requirement assertions")
+}
+
+type levelValue struct {
+	mask  Levels
+	value *Levels
+}
+
+func (lv levelValue) Get() interface{} {
+	return *lv.value & lv.mask
+}
+
+func (lv levelValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+
+	if v {
+		*lv.value = *lv.value | lv.mask // set
+	} else {
+		*lv.value = *lv.value &^ lv.mask // clear
+	}
+
+	return nil
+}
+
+func (lv levelValue) IsBoolFlag() bool {
+	return true
+}
+
+func (lv levelValue) String() string {
+	if lv.value != nil && lv.mask&*lv.value != 0 {
+		return "true"
+	}
+
+	return "false"
+}
+
+var mapping = [...]struct {
+	level Levels
+	name  string
+}{
+	{Must, "MUST"},
+	{MustNot, "MUST NOT"},
+	{Should, "SHOULD"},
+	{ShouldNot, "SHOULD NOT"},
+	{May, "MAY"},
+}

--- a/pkg/test/requirement/level.go
+++ b/pkg/test/requirement/level.go
@@ -43,24 +43,6 @@ const (
 	// May means that an item is truly optional
 	May
 
-	// TODO(dprotaso) Do we want these aliases?
-	// // Required means that the definition is an absolute requirement of the specification.
-	// Required = Must
-
-	// // Shall means that the definition is an absolute requirement of the specification.
-	// Shall = Must
-
-	// // ShallNot means that the definition is an absolute prohibition of the specification.
-	// ShallNot = MustNot
-
-	// // Recommended means that there may exist valid reasons in particular circumstances to
-	// // ignore a particular item
-	// Recommended = Should
-
-	// // NotRecommended means that there may exist valid reasons in particular circumstances when the
-	// // particular behavior is acceptable or even useful
-	// NotRecommended = ShouldNot
-
 	// All flag enables all requirement levels
 	All = Must | MustNot | Should | ShouldNot | May
 )

--- a/pkg/test/requirement/level.go
+++ b/pkg/test/requirement/level.go
@@ -25,6 +25,8 @@ import (
 
 type Levels uint8
 
+// Descriptions from: https://tools.ietf.org/html/rfc2119
+
 const (
 	// Must means that the definition is an absolute requirement of the specification.
 	Must Levels = 1 << iota

--- a/pkg/test/requirement/level_test.go
+++ b/pkg/test/requirement/level_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirement
+
+import (
+	"flag"
+	"io/ioutil"
+	"testing"
+)
+
+var cases = []struct {
+	level Levels
+	flag  string
+}{
+	{Must, "-requirement.must"},
+	{MustNot, "-requirement.mustnot"},
+	{Should, "-requirement.should"},
+	{ShouldNot, "-requirement.shouldnot"},
+	{May, "-requirement.may"},
+}
+
+func TestTurnOn(t *testing.T) {
+	for _, tc := range cases {
+		var l Levels
+
+		fs := &flag.FlagSet{}
+		fs.SetOutput(ioutil.Discard)
+		l.AddFlags(fs)
+
+		if err := fs.Parse([]string{tc.flag}); err != nil {
+			t.Fatal(err)
+		}
+
+		if l&tc.level == 0 {
+			t.Errorf("flag %q did not enable %s", tc.flag, tc.level)
+		}
+	}
+}
+
+func TestTurnOff(t *testing.T) {
+	for _, tc := range cases {
+		l := ^Levels(0)
+
+		fs := &flag.FlagSet{}
+		fs.SetOutput(ioutil.Discard)
+		l.AddFlags(fs)
+
+		if err := fs.Parse([]string{tc.flag + "=false"}); err != nil {
+			t.Fatal(err)
+		}
+
+		if l&tc.level != 0 {
+			t.Errorf("flag %q did not disable %s", tc.flag, tc.level)
+		}
+	}
+}


### PR DESCRIPTION
[Previously in #8](https://github.com/knative-sandbox/reconciler-test/pull/8/files#) I had `test.T`  separate from the `Config` interface. In practice this meant you had to cast the config to access certain properties.

I merged the two in this PR and changed the required signature when invoking subtests.

The functions that should be passed to subtests (`Run`, `Alpha`, `Must` etc..) should be take the same context that invoked the test

```go
// in my _test.go file
func RunConformance(t *testing.T) {
  ctx := MyTestContext{...}
  test.Init(ctx, t)
  ctx.Alpha("some alpha feature", TestAlphaFeature)
}

// somewhere else
func TestAlphaFeature(ctx *MyTestContext) {
  ctx.Must("do something", func(subctx *MyTestContext) {
     subctx.Fatal("failed to do something")
  })
}
```

I also realize eventing didn't use a ton of properties in the `environment.Settings` so I'm trying to break it up and not embed anything in the default `BaseContext`