### PR TITLE
Change how we default feature states & requirement levels

### DIFF
--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -122,6 +122,13 @@ func Init(c interface{}, t *testing.T) {
 }
 
 func (t *T) set(c interface{}, gotest *testing.T) {
+	// Default to all
+	if t.RequirementLevels == 0 {
+		t.RequirementLevels = requirement.All
+	}
+	if t.FeatureStates == 0 {
+		t.FeatureStates = feature.All
+	}
 	t.self = c
 	t.T = gotest
 }
@@ -132,13 +139,6 @@ func (t *T) set(c interface{}, gotest *testing.T) {
 // Calling AddFlags will also default the requirement level and
 // feature states to test everything
 func (t *T) AddFlags(fs *flag.FlagSet) {
-	if t.RequirementLevels == 0 {
-		t.RequirementLevels = requirement.All
-	}
-	if t.FeatureStates == 0 {
-		t.FeatureStates = feature.All
-	}
-
 	t.RequirementLevels.AddFlags(fs)
 	t.FeatureStates.AddFlags(fs)
 }

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -41,6 +41,17 @@ func TestFlags(t *testing.T) {
 		t.Fatal("failed to parse", err)
 	}
 
+	if got, want := ctx.RequirementLevels, requirement.Levels(0); got != want {
+		t.Errorf("wrong requirement level - got: %s want: %s", got, want)
+	}
+
+	if got, want := ctx.FeatureStates, feature.States(0); got != want {
+		t.Errorf("wrong requirement level - got: %s want: %s", got, want)
+	}
+
+	// defaulting
+	test.Init(&ctx, t)
+
 	if got, want := ctx.RequirementLevels, requirement.All; got != want {
 		t.Errorf("wrong requirement level - got: %s want: %s", got, want)
 	}


### PR DESCRIPTION
Defaulting to `All` in AddFlags didn't allow for a user to enable a specific level or state because internally we were ORing with a bitset