### PR TITLE
Use ko:// to signal that we would like the test framework to produce images.

### DIFF
--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -69,9 +69,7 @@ func ProduceImages() (map[string]string, error) {
 				propErr = err
 				return
 			}
-			i := strings.Split(pack, "/")
-			// TODO: the current key is too small, we will need to follow-up and change the image to be more complex to avoid shadowing.
-			packageToImageConfig[i[len(i)-1]] = strings.TrimSpace(image)
+			packageToImageConfig["ko://"+pack] = strings.TrimSpace(image)
 		}
 	})
 	return packageToImageConfig, propErr

--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -30,7 +30,9 @@ var packaged sync.Once
 
 // RegisterPackage registers an interest in producing an image based on the
 // provide package.
-// Can be called multiple times with the same package
+// Can be called multiple times with the same package.
+// A package will be used to produce the image and used
+// like `image: ko://<package>` inside test yaml.
 func RegisterPackage(pack ...string) {
 	for _, p := range pack {
 		exists := false
@@ -50,7 +52,7 @@ func RegisterPackage(pack ...string) {
 // instead. Should be called before ProduceImages(), if used, likely in an
 // init() method. An images value should be a container registry image. The
 // images map is presented to the templates on the field `images`, and used
-// like {{ .image.<key> }}.
+// like `image: <key>` inside test yaml.
 func WithImages(images map[string]string) {
 	packaged.Do(func() {
 		packageToImageConfig = images

--- a/pkg/environment/interfaces.go
+++ b/pkg/environment/interfaces.go
@@ -50,6 +50,8 @@ type Environment interface {
 
 	// Images returns back the name to container image mapping to be used with
 	// yaml template parsing.
+	// The map will be in the form `key`: `image` and `key` and the intention
+	// usage is to use this key to string substitute for image in test yaml.
 	Images() map[string]string
 	// TemplateConfig returns the base template config to use when processing
 	// yaml templates.

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -107,7 +107,6 @@ func (mr *MagicEnvironment) TemplateConfig(base map[string]interface{}) map[stri
 	for k, v := range base {
 		cfg[k] = v
 	}
-	cfg["images"] = mr.images
 	cfg["namespace"] = mr.namespace
 	return cfg
 }

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/injection/clients/dynamicclient"
+	"log"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+)
+
+func WaitForReadyOrDone(ctx context.Context, ref corev1.ObjectReference, interval, timeout time.Duration) error {
+	k := ref.GroupVersionKind()
+	gvr, _ := meta.UnsafeGuessKindToResource(k)
+
+	switch gvr.Resource {
+	case "jobs":
+		err := WaitUntilJobDone(kubeclient.Get(ctx), ref.Namespace, ref.Name, interval, timeout)
+		if err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		err := WaitForResourceReady(ctx, ref.Namespace, ref.Name, gvr, interval, timeout)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WaitForResourceReady waits until the specified resource in the given namespace are ready.
+func WaitForResourceReady(ctx context.Context, namespace, name string, gvr schema.GroupVersionResource, interval, timeout time.Duration) error {
+	lastMsg := ""
+	like := &duckv1.KResource{}
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		client := dynamicclient.Get(ctx)
+
+		us, err := client.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Println(namespace, name, "not found", err)
+				// keep polling
+				return false, nil
+			}
+			return false, err
+		}
+		obj := like.DeepCopy()
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(us.Object, obj); err != nil {
+			log.Fatalf("Error DefaultUnstructuree.Dynamiconverter. %v", err)
+		}
+		obj.ResourceVersion = gvr.Version
+		obj.APIVersion = gvr.GroupVersion().String()
+
+		ready := obj.Status.GetCondition(apis.ConditionReady)
+		if ready != nil && !ready.IsTrue() {
+			msg := fmt.Sprintf("%s is not ready, %s: %s", name, ready.Reason, ready.Message)
+			if msg != lastMsg {
+				log.Println(msg)
+				lastMsg = msg
+			}
+		}
+
+		return ready.IsTrue(), nil
+	})
+}

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -17,11 +17,14 @@ limitations under the License.
 package manifest
 
 import (
+	"bufio"
 	"context"
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -36,7 +39,7 @@ func InstallLocalYaml(ctx context.Context, base map[string]interface{}) (Manifes
 	_, filename, _, _ := runtime.Caller(1)
 	log.Println("FILENAME: ", filename)
 
-	yamls, err := ParseTemplates(path.Dir(filename), cfg)
+	yamls, err := ParseTemplates(path.Dir(filename), env.Images(), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -63,4 +66,38 @@ func InstallLocalYaml(ctx context.Context, base map[string]interface{}) (Manifes
 		log.Println(ref)
 	}
 	return manifest, nil
+}
+
+func ImagesLocalYaml() []string {
+	pwd, _ := os.Getwd()
+	log.Println("PWD: ", pwd)
+	_, filename, _, _ := runtime.Caller(1)
+	log.Println("FILENAME: ", filename)
+
+	var images []string
+
+	_ = filepath.Walk(path.Dir(filename), func(root string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), "yaml") {
+			file, err := os.Open(root)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer file.Close()
+
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				parts := strings.Split(scanner.Text(), "ko://")
+				if len(parts) == 2 {
+					image := strings.ReplaceAll(parts[1], "\"", "")
+					images = append(images, image)
+				}
+			}
+		}
+		return nil
+	})
+
+	return images
 }

--- a/pkg/manifest/templates.go
+++ b/pkg/manifest/templates.go
@@ -29,7 +29,7 @@ import (
 // ParseTemplates walks through all the template yaml file in the given directory
 // and produces instantiated yaml file in a temporary directory.
 // Return the name of the temporary directory
-func ParseTemplates(path string, data map[string]interface{}) (string, error) {
+func ParseTemplates(path string, images map[string]string, data map[string]interface{}) (string, error) {
 	dir, err := ioutil.TempDir("", "processed_yaml")
 	if err != nil {
 		panic(err)
@@ -53,6 +53,19 @@ func ParseTemplates(path string, data map[string]interface{}) (string, error) {
 				log.Print("execute: ", err)
 				return err
 			}
+
+			// Set image.
+			read, err := ioutil.ReadFile(path)
+			newContents := string(read)
+			for key, image := range images {
+				newContents = strings.Replace(newContents, key, image, -1)
+			}
+			err = ioutil.WriteFile(path, []byte(newContents), 0)
+			if err != nil {
+				log.Print("write file: ", err)
+				return err
+			}
+
 			_ = tmpfile.Close()
 		}
 		return nil

--- a/pkg/manifest/templates.go
+++ b/pkg/manifest/templates.go
@@ -55,18 +55,18 @@ func ParseTemplates(path string, images map[string]string, data map[string]inter
 			}
 
 			// Set image.
-			read, err := ioutil.ReadFile(path)
+			read, err := ioutil.ReadAll(tmpfile)
 			newContents := string(read)
 			for key, image := range images {
 				newContents = strings.Replace(newContents, key, image, -1)
 			}
-			err = ioutil.WriteFile(path, []byte(newContents), 0)
+			_ = tmpfile.Close()
+
+			err = ioutil.WriteFile(tmpfile.Name(), []byte(newContents), 0)
 			if err != nil {
 				log.Print("write file: ", err)
 				return err
 			}
-
-			_ = tmpfile.Close()
 		}
 		return nil
 	})

--- a/pkg/manifest/templates.go
+++ b/pkg/manifest/templates.go
@@ -53,14 +53,14 @@ func ParseTemplates(path string, images map[string]string, data map[string]inter
 				log.Print("execute: ", err)
 				return err
 			}
+			_ = tmpfile.Close()
 
 			// Set image.
-			read, err := ioutil.ReadAll(tmpfile)
+			read, err := ioutil.ReadFile(tmpfile.Name())
 			newContents := string(read)
 			for key, image := range images {
 				newContents = strings.Replace(newContents, key, image, -1)
 			}
-			_ = tmpfile.Close()
 
 			err = ioutil.WriteFile(tmpfile.Name(), []byte(newContents), 0)
 			if err != nil {

--- a/test/example/config/echo/echo.go
+++ b/test/example/config/echo/echo.go
@@ -26,9 +26,7 @@ import (
 )
 
 func init() {
-	environment.RegisterPackage(
-		"knative.dev/reconciler-test/test/example/cmd/echo",
-	)
+	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
 }
 
 // Output is the base output we can expect from a echo job.

--- a/test/example/config/echo/echo.yaml
+++ b/test/example/config/echo/echo.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: echo
-          image: {{ .images.echo }}
+          image: azd2k.azurecr.io/kn/echo@sha256:0933ea6bf2799b08653c0e729d63372629b42c69331125d2428edeb25c57637b
           env:
             - name: ECHO
               value: "{{ .message }}"

--- a/test/example/config/echo/echo.yaml
+++ b/test/example/config/echo/echo.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: echo
-          image: azd2k.azurecr.io/kn/echo@sha256:0933ea6bf2799b08653c0e729d63372629b42c69331125d2428edeb25c57637b
+          image: ko://knative.dev/reconciler-test/test/example/cmd/echo
           env:
             - name: ECHO
               value: "{{ .message }}"

--- a/test/example/config/producer/producer.go
+++ b/test/example/config/producer/producer.go
@@ -28,9 +28,7 @@ import (
 )
 
 func init() {
-	environment.RegisterPackage(
-		"knative.dev/reconciler-test/test/example/cmd/producer",
-	)
+	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
 }
 
 func Install(sendCount int, svcName string) feature.StepFn {

--- a/test/example/config/producer/producer.yaml
+++ b/test/example/config/producer/producer.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: producer
-          image: azd2k.azurecr.io/kn/producer@sha256:7ed12ab13b4828ab1a3797c52aea09c40681d6c79237e86ca9050041fd4ab008
+          image: ko://knative.dev/reconciler-test/test/example/cmd/producer
           env:
             - name: COUNT
               value: '{{ .count }}'

--- a/test/example/config/producer/producer.yaml
+++ b/test/example/config/producer/producer.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: producer
-          image: {{ .images.producer }}
+          image: azd2k.azurecr.io/kn/producer@sha256:7ed12ab13b4828ab1a3797c52aea09c40681d6c79237e86ca9050041fd4ab008
           env:
             - name: COUNT
               value: '{{ .count }}'

--- a/test/example/config/recorder/recorder.go
+++ b/test/example/config/recorder/recorder.go
@@ -31,9 +31,7 @@ import (
 )
 
 func init() {
-	environment.RegisterPackage(
-		"knative.dev/reconciler-test/images/recorder",
-	)
+	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
 }
 
 func Install(recorderName string) feature.StepFn {

--- a/test/example/config/recorder/recorder.yaml
+++ b/test/example/config/recorder/recorder.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccount: recorder
       containers:
         - name: recorder
-          image: azd2k.azurecr.io/kn/recorder@sha256:1938a18961f21262278dc03d18be190c630bef95a9ca0c62ca08af2528dbfd86
+          image: ko://knative.dev/reconciler-test/images/recorder
           env:
             - name: SYSTEM_NAMESPACE
               value: {{ .namespace }}

--- a/test/example/config/recorder/recorder.yaml
+++ b/test/example/config/recorder/recorder.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccount: recorder
       containers:
         - name: recorder
-          image: {{ .images.recorder }}
+          image: azd2k.azurecr.io/kn/recorder@sha256:1938a18961f21262278dc03d18be190c630bef95a9ca0c62ca08af2528dbfd86
           env:
             - name: SYSTEM_NAMESPACE
               value: {{ .namespace }}


### PR DESCRIPTION
tl;dr: `image: { .images.magicName }` --> `image: ko://some/go/package`

Fixes: https://github.com/knative-sandbox/reconciler-test/issues/34

This change takes some opinions out of the testing framework, we will use `ko://` to signal we want to make a container. 

This is overwritten if you use something like the following:

```
// The following could be used to bypass the image generation process.

import "knative.dev/reconciler-test/pkg/environment"

func init() {
	environment.WithImages(map[string]string{
		"ko://knative.dev/reconciler-test/images/recorder": "example.azurecr.io/kn/recorder@sha256:1938a18961f21262278dc03d18be190c630bef95a9ca0c62ca08af2528dbfd86",
		"ko://knative.dev/reconciler-test/test/example/cmd/echo": "example.azurecr.io/kn/echo@sha256:0933ea6bf2799b08653c0e729d63372629b42c69331125d2428edeb25c57637b",
		"ko://knative.dev/reconciler-test/test/example/cmd/producer": "example.azurecr.io/kn/producer@sha256:7ed12ab13b4828ab1a3797c52aea09c40681d6c79237e86ca9050041fd4ab008",

	})
}
```

At the moment, if WithImage is set, then ProduceImages will do nothing. We could do a followup to be more smart about this, but for now, let's try this out.