### PR TITLE
adding dependency method

### DIFF
--- a/pkg/environment/interfaces.go
+++ b/pkg/environment/interfaces.go
@@ -37,6 +37,10 @@ type GlobalEnvironment interface {
 
 // Environment is the ephemeral testing environment to test features.
 type Environment interface {
+	// Dependency will execute the feature using the given Context and T,
+	// the feature should not have any asserts.
+	Dependency(ctx context.Context, t *testing.T, f *feature.Feature)
+
 	// Test will execute the feature test using the given Context and T.
 	Test(ctx context.Context, t *testing.T, f *feature.Feature)
 

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -123,6 +123,13 @@ func (mr *MagicEnvironment) Namespace() string {
 	return mr.namespace
 }
 
+func (mr *MagicEnvironment) Dependency(ctx context.Context, t *testing.T, f *feature.Feature) {
+	t.Helper() // Helper marks the calling function as a test helper function.
+	t.Run("Dependency", func(t *testing.T) {
+		mr.Test(ctx, t, f)
+	})
+}
+
 func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.Feature) {
 	t.Helper() // Helper marks the calling function as a test helper function.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

There are times where we need to apply or validate a dependency to an environment but it is awkward to make that a `Test()` if it is intended to be pure setup, like making a namespaced component that will be used by some underlying infrastructure code (like rabbitmq brokers in a namespace, which are used by the Broker CO, but not directly by the test)

- :gift: Adding `env.Dependency()`.

/kind api-change

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adding `env.Dependency()`, just like `env.Test()` except we can make it clear it is not a Test, but some required other thing to be applied to the environment in the logs and results.
```
