### PR TITLE
Running constraints of different timings

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -133,6 +133,8 @@ func (mr *MagicEnvironment) Prerequisite(ctx context.Context, t *testing.T, f *f
 func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.Feature) {
 	t.Helper() // Helper marks the calling function as a test helper function.
 
+	steps := feature.CollapseSteps(f.Steps)
+
 	for _, timing := range feature.Timings() {
 		// do it the slow way first.
 		wg := &sync.WaitGroup{}
@@ -142,7 +144,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 			t.Helper()      // Helper marks the calling function as a test helper function.
 			defer wg.Done() // Outer wait.
 
-			for _, s := range f.Steps {
+			for _, s := range steps {
 				// Skip if step phase is not running.
 				if s.T != timing {
 					continue

--- a/pkg/feature/collapse.go
+++ b/pkg/feature/collapse.go
@@ -1,0 +1,76 @@
+package feature
+
+import (
+	"context"
+	"testing"
+)
+
+// CollapseSteps is used by the framework to impose the execution constraints of the different steps
+// Steps with Setup, Requirement and Teardown timings are run sequentially in order
+// Steps with Assert timing are run in parallel
+func CollapseSteps(steps []Step) []Step {
+	var setup *Step
+	var requirement *Step
+	var asserts []Step
+	var teardown *Step
+
+	for i, s := range steps {
+		if s.T == Setup {
+			setup = composeStep(setup, &steps[i])
+		} else if s.T == Requirement {
+			requirement = composeStep(requirement, &steps[i])
+		} else if s.T == Assert {
+			asserts = append(asserts, parallelizeStep(s))
+		} else if s.T == Teardown {
+			teardown = composeStep(teardown, &steps[i])
+		}
+	}
+
+	var result []Step
+	if setup != nil {
+		result = append(result, *setup)
+	}
+	if requirement != nil {
+		result = append(result, *requirement)
+	}
+	result = append(result, asserts...)
+	if teardown != nil {
+		result = append(result, *teardown)
+	}
+
+	return result
+}
+
+func composeStep(x *Step, y *Step) *Step {
+	if x == nil {
+		return y
+	}
+	if y == nil {
+		return x
+	}
+	return &Step{
+		Name: x.Name + " and " + y.Name,
+		S:    x.S,
+		L:    x.L,
+		T:    x.T,
+		Fn: func(ctx context.Context, t *testing.T) {
+			t.Helper()
+			x.Fn(ctx, t)
+			y.Fn(ctx, t)
+		},
+	}
+}
+
+func parallelizeStep(x Step) Step {
+	return Step{
+		Name: x.Name,
+		S:    x.S,
+		L:    x.L,
+		T:    x.T,
+		Fn: func(ctx context.Context, t *testing.T) {
+			t.Parallel()
+			t.Helper()
+			x.Fn(ctx, t)
+		},
+	}
+}

--- a/pkg/feature/collapse.go
+++ b/pkg/feature/collapse.go
@@ -9,19 +9,20 @@ import (
 // Steps with Setup, Requirement and Teardown timings are run sequentially in order
 // Steps with Assert timing are run in parallel
 func CollapseSteps(steps []Step) []Step {
-	var setup *Step
-	var requirement *Step
-	var asserts []Step
-	var teardown *Step
+	var (
+		setup, requirement, teardown *Step
+		asserts                      []Step
+	)
 
 	for i, s := range steps {
-		if s.T == Setup {
+		switch s.T {
+		case Setup:
 			setup = composeStep(setup, &steps[i])
-		} else if s.T == Requirement {
+		case Requirement:
 			requirement = composeStep(requirement, &steps[i])
-		} else if s.T == Assert {
+		case Assert:
 			asserts = append(asserts, parallelizeStep(s))
-		} else if s.T == Teardown {
+		case Teardown:
 			teardown = composeStep(teardown, &steps[i])
 		}
 	}

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -1,0 +1,64 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func TestTimingConstraints(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment()
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := &feature.Feature{}
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", appender(stringBuilder, "setup2"))
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
+	feat.Requirement("requirement2", appender(stringBuilder, "requirement2"))
+	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
+	feat.Stable("aaa").Must("bbb", func(ctx context.Context, t *testing.T) {})
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1setup2setup3requirement1requirement2requirement3teardown1teardown2teardown3", stringBuilder.String())
+}
+
+func appender(stringBuilder *strings.Builder, val string) feature.StepFn {
+	return func(ctx context.Context, t *testing.T) {
+		stringBuilder.WriteString(val)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,64 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"knative.dev/pkg/injection"
+	_ "knative.dev/pkg/system/testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// global is the singleton instance of GlobalEnvironment. It is used to parse
+// the testing config for the test run. The config will specify the cluster
+// config as well as the parsing level and state flags.
+var global environment.GlobalEnvironment
+
+func init() {
+	// environment.InitFlags registers state and level filter flags.
+	environment.InitFlags(flag.CommandLine)
+}
+
+// TestMain is the first entry point for `go test`.
+func TestMain(m *testing.M) {
+	// We get a chance to parse flags to include the framework flags for the
+	// framework as well as any additional flags included in the integration.
+	flag.Parse()
+
+	// EnableInjectionOrDie will enable client injection, this is used by the
+	// testing framework for namespace management, and could be leveraged by
+	// features to pull Kubernetes clients or the test environment out of the
+	// context passed in the features.
+	ctx, startInformers := injection.EnableInjectionOrDie(nil, nil) //nolint
+	startInformers()
+
+	// global is used to make instances of Environments, NewGlobalEnvironment
+	// is passing and saving the client injection enabled context for use later.
+	global = environment.NewGlobalEnvironment(ctx)
+
+	// Run the tests.
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Now `Setup`, `Teardown` and `Requirement` run ordered and sequentially, while `Assert` is tagged to run in parallel. This makes the setup, teardown and requirement phases of the test predictable
- :gift: Test for the runtime constraints of the tests