### PR TITLE
KResource has address as a pointer, test it for nil

### DIFF
--- a/pkg/k8s/steps.go
+++ b/pkg/k8s/steps.go
@@ -77,7 +77,7 @@ func IsAddressable(gvr schema.GroupVersionResource, name string, interval, timeo
 			obj.ResourceVersion = gvr.Version
 			obj.APIVersion = gvr.GroupVersion().String()
 
-			if obj.Status.Address.URL == nil {
+			if obj.Status.Address == nil || obj.Status.Address.URL == nil {
 				msg := fmt.Sprintf("%s %s has no status.address.url, %s", gvr, name, err)
 				if msg != lastMsg {
 					log.Println(msg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: The original IsAddressable code came from Brokers, Brokers do not have address pointers or I never ran into a case where it was nil. Was getting NPE when integrating the method. This fixes those issues.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix NPE on k8s.IsAddressable().
```

