### PR TITLE
Add utility to return the address of an Addressable.

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -45,6 +45,15 @@ func StartSender(sinkSvc string) EventsHubOption {
 	})
 }
 
+// StartSenderURL starts the sender in the eventshub sinking to a URL.
+// This can be used together with InputEvent, AddTracing, EnableIncrementalId, InputEncoding and InputHeader options
+func StartSenderURL(sink string) EventsHubOption {
+	return compose(envAdditive("EVENT_GENERATORS", "sender"), func(ctx context.Context, envs map[string]string) error {
+		envs["SINK"] = sink
+		return nil
+	})
+}
+
 // --- Receiver options
 
 // EchoEvent is an option to let the eventshub reply with the received event


### PR DESCRIPTION
# Changes

- `k8s.Address()` returns the url of an addressable.
- `k8s.IsAddress()` uses `k8s.Address()`
- New entry for eventshub: `StartSenderURL`, to pass the sink directly as a url.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adding `k8s.Address()`, it returns the url of an addressable.
Adding `eventshub.StartSenderURL()`, to pass the sink directly as a url.
```
