### PR TITLE
Improve eventshub assertions UX

### DIFF
--- a/pkg/eventshub/assert/doc.go
+++ b/pkg/eventshub/assert/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+assert contains the necessary matchers and steps to perform assertions on eventshub contents
+*/
+package assert

--- a/pkg/eventshub/assert/step.go
+++ b/pkg/eventshub/assert/step.go
@@ -1,4 +1,4 @@
-package eventshub
+package assert
 
 import (
 	"context"
@@ -6,12 +6,13 @@ import (
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 
+	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
 type MatchAssertionBuilder struct {
 	storeName string
-	matchers  []EventInfoMatcher
+	matchers  []eventshub.EventInfoMatcher
 }
 
 // OnStore creates an assertion builder starting from the name of the store
@@ -23,7 +24,7 @@ func OnStore(name string) MatchAssertionBuilder {
 }
 
 // Match adds the provided matchers in this builder
-func (m MatchAssertionBuilder) Match(matchers ...EventInfoMatcher) MatchAssertionBuilder {
+func (m MatchAssertionBuilder) Match(matchers ...eventshub.EventInfoMatcher) MatchAssertionBuilder {
 	m.matchers = append(m.matchers, matchers...)
 	return m
 }
@@ -38,7 +39,7 @@ func (m MatchAssertionBuilder) MatchEvent(matchers ...cetest.EventMatcher) Match
 // OnStore(store).Match(matchers).AtLeast(min) is equivalent to StoreFromContext(ctx, store).AssertAtLeast(min, matchers)
 func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 	return func(ctx context.Context, t *testing.T) {
-		StoreFromContext(ctx, m.storeName).AssertAtLeast(min, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(min, m.matchers...)
 	}
 }
 
@@ -46,7 +47,7 @@ func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 // OnStore(store).Match(matchers).InRange(min, max) is equivalent to StoreFromContext(ctx, store).AssertInRange(min, max, matchers)
 func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 	return func(ctx context.Context, t *testing.T) {
-		StoreFromContext(ctx, m.storeName).AssertInRange(min, max, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(min, max, m.matchers...)
 	}
 }
 
@@ -54,7 +55,7 @@ func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 // OnStore(store).Match(matchers).Exact(n) is equivalent to StoreFromContext(ctx, store).AssertExact(n, matchers)
 func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 	return func(ctx context.Context, t *testing.T) {
-		StoreFromContext(ctx, m.storeName).AssertExact(n, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(n, m.matchers...)
 	}
 }
 
@@ -62,6 +63,6 @@ func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 // OnStore(store).Match(matchers).Not() is equivalent to StoreFromContext(ctx, store).AssertNot(matchers)
 func (m MatchAssertionBuilder) Not() feature.StepFn {
 	return func(ctx context.Context, t *testing.T) {
-		StoreFromContext(ctx, m.storeName).AssertNot(m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(m.matchers...)
 	}
 }

--- a/test/example/recorder_feature.go
+++ b/test/example/recorder_feature.go
@@ -21,11 +21,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	. "github.com/cloudevents/sdk-go/v2/test"
-
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
+
+	// Dot import the eventshub asserts and sdk-go test packages to include all the assert utilities
+	. "github.com/cloudevents/sdk-go/v2/test"
+	. "knative.dev/reconciler-test/pkg/eventshub/assert"
 )
 
 func RecorderFeature() *feature.Feature {
@@ -45,7 +47,7 @@ func RecorderFeature() *feature.Feature {
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the recorder received all sent events within the time",
-			eventshub.OnStore(to).MatchEvent(HasId(event.ID())).Exact(1),
+			OnStore(to).MatchEvent(HasId(event.ID())).Exact(1),
 		)
 
 	return f


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Moved all the asserts under a specific package to simplify the assertions usage
- :gift: Added a matcher for status code
- :gift: Added an eventshub option to send directly to an addressable matcher for status code