### PR TITLE
Allow to specify platform for reconciler test

### DIFF
--- a/pkg/images/ko.go
+++ b/pkg/images/ko.go
@@ -18,12 +18,16 @@ package images
 
 import (
 	"fmt"
+	"os"
 )
 
 // Use ko to publish the image.
 func KoPublish(path string) (string, error) {
-	fmt.Println(fmt.Sprintf("ko publish -B %s", path))
-	out, err := runCmd(fmt.Sprintf("ko publish -B %s", path))
+	platform := os.Getenv("PLATFORM")
+	if len(platform) > 0 {
+		platform = " --platform=" + platform
+	}
+	out, err := runCmd(fmt.Sprintf("ko publish%s -B %s", platform, path))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This is to make the reconciler test configurable for different platforms. This change is in line with https://github.com/knative/eventing/pull/4763.

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add an argument `--platform` if the env variable `PLATFORM` is set, otherwise the argument is empty.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

