### PR TITLE
Context cancelling should be tied to the single test execution

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -150,6 +150,9 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 					continue
 				}
 				t.Run(s.TestName(), func(t *testing.T) {
+					ctx, cancelFn := context.WithCancel(ctx)
+					t.Cleanup(cancelFn)
+
 					wg.Add(1)
 					defer wg.Done()
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This should fix https://github.com/knative/eventing/issues/4637