### PR TITLE
Refactoring feature steps execution

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,10 +17,10 @@ jobs:
       KO_DOCKER_REPO: kind.local
 
     steps:
-    - name: Set up Go 1.14.x
+    - name: Set up Go 1.15.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
 
     - name: Install Dependencies
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/reconciler-test
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.2.0

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -133,9 +133,14 @@ func (mr *MagicEnvironment) Prerequisite(ctx context.Context, t *testing.T, f *f
 func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.Feature) {
 	t.Helper() // Helper marks the calling function as a test helper function.
 
-	steps := feature.CollapseSteps(f.Steps)
+	steps := feature.ReorderSteps(f.Steps)
+
+	for _, s := range steps {
+		t.Run()
+	}
 
 	for _, timing := range feature.Timings() {
+
 		// do it the slow way first.
 		wg := &sync.WaitGroup{}
 		wg.Add(1)

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -146,9 +146,9 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 		skipped, failed, duration := mr.safeExecuteStep(ctx, t, s)
 
 		if skipped {
-			fmt.Printf("    --- %s: %s/[%s]%s (%.2fs) \n", skip, t.Name(), featureTestName, stepName, duration.Seconds())
+			fmt.Printf("    --- %s: %s/[%s]%s (%.2fs) \n\n", skip, t.Name(), featureTestName, stepName, duration.Seconds())
 		} else if failed {
-			fmt.Printf("    --- %s: %s/[%s]%s (%.2fs) \n", fail, t.Name(), featureTestName, stepName, duration.Seconds())
+			fmt.Printf("    --- %s: %s/[%s]%s (%.2fs) \n\n", fail, t.Name(), featureTestName, stepName, duration.Seconds())
 			t.FailNow() // Here we can have different policies, depending on feature level etc
 		} else {
 			fmt.Printf("    --- %s: %s/[%s]%s (%.2fs) \n\n", pass, t.Name(), featureTestName, stepName, duration.Seconds())

--- a/pkg/environment/t.go
+++ b/pkg/environment/t.go
@@ -1,0 +1,74 @@
+package environment
+
+import (
+	"runtime"
+	"testing"
+
+	"go.uber.org/atomic"
+)
+
+type t struct {
+	t *testing.T
+
+	failed  *atomic.Bool
+	skipped *atomic.Bool
+}
+
+func (t *t) Error(args ...interface{}) {
+	t.t.Helper()
+	t.t.Log(args...)
+}
+
+func (t *t) Errorf(format string, args ...interface{}) {
+	t.t.Helper()
+	t.t.Logf(format, args...)
+	t.Fail()
+}
+
+func (t *t) Fail() {
+	t.failed.Store(true)
+}
+
+func (t *t) Fatal(args ...interface{}) {
+	t.t.Helper()
+	t.t.Log(args...)
+	t.FailNow()
+}
+
+func (t *t) Fatalf(format string, args ...interface{}) {
+	t.t.Helper()
+	t.t.Logf(format, args...)
+	t.FailNow()
+}
+
+func (t *t) FailNow() {
+	t.failed.Store(true)
+	runtime.Goexit()
+}
+
+func (t *t) Log(args ...interface{}) {
+	t.t.Helper()
+	t.t.Log(args...)
+}
+
+func (t *t) Logf(format string, args ...interface{}) {
+	t.t.Helper()
+	t.t.Logf(format, args...)
+}
+
+func (t *t) Skip(args ...interface{}) {
+	t.t.Helper()
+	t.t.Log(args...)
+	t.SkipNow()
+}
+
+func (t *t) Skipf(format string, args ...interface{}) {
+	t.t.Helper()
+	t.t.Logf(format, args...)
+	t.SkipNow()
+}
+
+func (t *t) SkipNow() {
+	t.skipped.Store(true)
+	runtime.Goexit()
+}

--- a/pkg/eventshub/assert/step.go
+++ b/pkg/eventshub/assert/step.go
@@ -2,7 +2,6 @@ package assert
 
 import (
 	"context"
-	"testing"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 
@@ -38,7 +37,7 @@ func (m MatchAssertionBuilder) MatchEvent(matchers ...cetest.EventMatcher) Match
 // AtLeast builds the assertion feature.StepFn
 // OnStore(store).Match(matchers).AtLeast(min) is equivalent to StoreFromContext(ctx, store).AssertAtLeast(min, matchers)
 func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(min, m.matchers...)
 	}
 }
@@ -46,7 +45,7 @@ func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 // InRange builds the assertion feature.StepFn
 // OnStore(store).Match(matchers).InRange(min, max) is equivalent to StoreFromContext(ctx, store).AssertInRange(min, max, matchers)
 func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(min, max, m.matchers...)
 	}
 }
@@ -54,7 +53,7 @@ func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 // Exact builds the assertion feature.StepFn
 // OnStore(store).Match(matchers).Exact(n) is equivalent to StoreFromContext(ctx, store).AssertExact(n, matchers)
 func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(n, m.matchers...)
 	}
 }
@@ -62,7 +61,7 @@ func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 // Not builds the assertion feature.StepFn
 // OnStore(store).Match(matchers).Not() is equivalent to StoreFromContext(ctx, store).AssertNot(matchers)
 func (m MatchAssertionBuilder) Not() feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(m.matchers...)
 	}
 }

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -19,7 +19,6 @@ package eventshub
 import (
 	"context"
 	"strings"
-	"testing"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -44,7 +43,7 @@ func init() {
 //     k8s.WithEventListener,
 //   )
 func Install(name string, options ...EventsHubOption) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		// Compute the user provided envs
 		envs := make(map[string]string)
 		if err := compose(options...)(ctx, envs); err != nil {

--- a/pkg/feature/collapse.go
+++ b/pkg/feature/collapse.go
@@ -11,11 +11,11 @@ func ReorderSteps(steps []Step) []Step {
 		case Setup:
 			setup = append(setup, s)
 		case Requirement:
-			requirement = append(setup, s)
+			requirement = append(requirement, s)
 		case Assert:
 			asserts = append(asserts, s)
 		case Teardown:
-			teardown = append(setup, s)
+			teardown = append(teardown, s)
 		}
 	}
 

--- a/pkg/feature/collapse.go
+++ b/pkg/feature/collapse.go
@@ -1,10 +1,5 @@
 package feature
 
-import (
-	"context"
-	"testing"
-)
-
 // ReorderSteps reorders steps as follows: Setup, Requirement, Assert and Teardown
 func ReorderSteps(steps []Step) []Step {
 	var (
@@ -31,75 +26,4 @@ func ReorderSteps(steps []Step) []Step {
 	result = append(result, teardown...)
 
 	return result
-}
-
-// CollapseSteps is used by the framework to impose the execution constraints of the different steps
-// Steps with Setup, Requirement and Teardown timings are run sequentially in order
-// Steps with Assert timing are run in parallel
-func CollapseSteps(steps []Step) []Step {
-	var (
-		setup, requirement, teardown *Step
-		asserts                      []Step
-	)
-
-	for i, s := range steps {
-		switch s.T {
-		case Setup:
-			setup = composeStep(setup, &steps[i])
-		case Requirement:
-			requirement = composeStep(requirement, &steps[i])
-		case Assert:
-			asserts = append(asserts, parallelizeStep(s))
-		case Teardown:
-			teardown = composeStep(teardown, &steps[i])
-		}
-	}
-
-	var result []Step
-	if setup != nil {
-		result = append(result, *setup)
-	}
-	if requirement != nil {
-		result = append(result, *requirement)
-	}
-	result = append(result, asserts...)
-	if teardown != nil {
-		result = append(result, *teardown)
-	}
-
-	return result
-}
-
-func composeStep(x *Step, y *Step) *Step {
-	if x == nil {
-		return y
-	}
-	if y == nil {
-		return x
-	}
-	return &Step{
-		Name: x.Name + " and " + y.Name,
-		S:    x.S,
-		L:    x.L,
-		T:    x.T,
-		Fn: func(ctx context.Context, t *testing.T) {
-			t.Helper()
-			x.Fn(ctx, t)
-			y.Fn(ctx, t)
-		},
-	}
-}
-
-func parallelizeStep(x Step) Step {
-	return Step{
-		Name: x.Name,
-		S:    x.S,
-		L:    x.L,
-		T:    x.T,
-		Fn: func(ctx context.Context, t *testing.T) {
-			t.Parallel()
-			t.Helper()
-			x.Fn(ctx, t)
-		},
-	}
 }

--- a/pkg/feature/collapse.go
+++ b/pkg/feature/collapse.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+// ReorderSteps reorders steps as follows: Setup, Requirement, Assert and Teardown
+func ReorderSteps(steps []Step) []Step {
+	var (
+		setup, requirement, asserts, teardown []Step
+	)
+
+	for _, s := range steps {
+		switch s.T {
+		case Setup:
+			setup = append(setup, s)
+		case Requirement:
+			requirement = append(setup, s)
+		case Assert:
+			asserts = append(asserts, s)
+		case Teardown:
+			teardown = append(setup, s)
+		}
+	}
+
+	var result []Step
+	result = append(result, setup...)
+	result = append(result, requirement...)
+	result = append(result, asserts...)
+	result = append(result, teardown...)
+
+	return result
+}
+
 // CollapseSteps is used by the framework to impose the execution constraints of the different steps
 // Steps with Setup, Requirement and Teardown timings are run sequentially in order
 // Steps with Assert timing are run in parallel

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -19,7 +19,6 @@ package feature
 import (
 	"context"
 	"fmt"
-	"testing"
 )
 
 // Feature is a list of steps and feature name.
@@ -29,7 +28,7 @@ type Feature struct {
 }
 
 // StepFn is the function signature for steps.
-type StepFn func(ctx context.Context, t *testing.T)
+type StepFn func(ctx context.Context, t T)
 
 // Step is a structure to hold the step function, step name and state, level and
 // timing configuration.

--- a/pkg/feature/t.go
+++ b/pkg/feature/t.go
@@ -1,0 +1,18 @@
+package feature
+
+type T interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
+
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	FailNow()
+
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+
+	Skip(args ...interface{})
+	Skipf(format string, args ...interface{})
+	SkipNow()
+}

--- a/pkg/images/cmd.go
+++ b/pkg/images/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package images
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -27,7 +28,9 @@ func cmd(cmdLine string) *exec.Cmd {
 	cmdSplit := strings.Split(cmdLine, " ")
 	cmd := cmdSplit[0]
 	args := cmdSplit[1:]
-	return exec.Command(cmd, args...)
+	c := exec.Command(cmd, args...)
+	c.Stderr = os.Stdout // Pipe the stderr in stdout
+	return c
 }
 
 func runCmd(cmdLine string) (string, error) {

--- a/pkg/k8s/steps.go
+++ b/pkg/k8s/steps.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"testing"
 	"time"
 
 	"knative.dev/pkg/apis"
@@ -34,6 +33,7 @@ import (
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/injection/clients/dynamicclient"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
@@ -41,7 +41,7 @@ import (
 // IsReady returns a reusable feature.StepFn to assert if a resource is ready
 // within the time given.
 func IsReady(gvr schema.GroupVersionResource, name string, interval, timeout time.Duration) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		env := environment.FromContext(ctx)
 		if err := WaitForResourceReady(ctx, env.Namespace(), name, gvr, interval, timeout); err != nil {
 			t.Error(gvr, "did not become ready,", err)
@@ -52,7 +52,7 @@ func IsReady(gvr schema.GroupVersionResource, name string, interval, timeout tim
 // IsAddressable tests to see if a resource becomes Addressable within the time
 // given.
 func IsAddressable(gvr schema.GroupVersionResource, name string, interval, timeout time.Duration) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		lastMsg := ""
 		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 			addr, err := Address(ctx, gvr, name)

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -19,7 +19,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +39,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 )
 
 func WaitForReadyOrDone(ctx context.Context, ref corev1.ObjectReference, interval, timeout time.Duration) error {
@@ -127,15 +127,15 @@ func WaitForResourceReady(ctx context.Context, namespace, name string, gvr schem
 }
 
 // WaitForServiceEndpointsOrFail wraps the utility from pkg and uses the context to extract kubeclient and namespace
-func WaitForServiceEndpointsOrFail(ctx context.Context, tb testing.TB, svcName string, numberOfExpectedEndpoints int) {
+func WaitForServiceEndpointsOrFail(ctx context.Context, t feature.T, svcName string, numberOfExpectedEndpoints int) {
 	if err := pkgtest.WaitForServiceEndpoints(ctx, kubeclient.Get(ctx), svcName, environment.FromContext(ctx).Namespace(), numberOfExpectedEndpoints); err != nil {
-		tb.Fatalf("Failed while waiting for %d endpoints in service %s: %+v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
+		t.Fatalf("Failed while waiting for %d endpoints in service %s: %+v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
 	}
 }
 
 // WaitForPodRunningOrFail wraps the utility from pkg and uses the context to extract kubeclient and namespace
-func WaitForPodRunningOrFail(ctx context.Context, tb testing.TB, podName string) {
+func WaitForPodRunningOrFail(ctx context.Context, t feature.T, podName string) {
 	if err := pkgtest.WaitForPodRunning(ctx, kubeclient.Get(ctx), podName, environment.FromContext(ctx).Namespace()); err != nil {
-		tb.Fatalf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err))
+		t.Fatalf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err))
 	}
 }

--- a/pkg/knative/logging_config.go
+++ b/pkg/knative/logging_config.go
@@ -34,7 +34,7 @@ func WithLoggingConfig(ctx context.Context, env environment.Environment) (contex
 	knativeNamespace := KnativeNamespaceFromContext(ctx)
 	cm, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(knativeNamespace).Get(context.Background(), logging.ConfigMapName(), metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error while retrieving the %s config map in namespace %s: %+v", logging.ConfigMapName(), knativeNamespaceConfig{}, errors.WithStack(err))
+		return nil, fmt.Errorf("error while retrieving the %s config map in namespace %s: %+v", logging.ConfigMapName(), knativeNamespace, errors.WithStack(err))
 	}
 
 	config, err := logging.NewConfigFromMap(cm.Data)

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -52,19 +52,19 @@ func TestTimingConstraints(t *testing.T) {
 	feat.Requirement("requirement2", appender(stringBuilder, "requirement2"))
 	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
 	feat.Stable("A cool feature").
-		Must("aaa", func(ctx context.Context, t *testing.T) {
+		Must("aaa", func(ctx context.Context, t feature.T) {
 			time.Sleep(1 * time.Second)
 			atomic.AddInt32(&counter, 1)
 		}).
-		Must("bbb", func(ctx context.Context, t *testing.T) {
+		Must("bbb", func(ctx context.Context, t feature.T) {
 			time.Sleep(1 * time.Second)
 			atomic.AddInt32(&counter, 1)
 		}).
-		Must("ccc", func(ctx context.Context, t *testing.T) {
+		Must("ccc", func(ctx context.Context, t feature.T) {
 			time.Sleep(1 * time.Second)
 			atomic.AddInt32(&counter, 1)
 		})
-	feat.Teardown("teardown0", func(ctx context.Context, t *testing.T) {
+	feat.Teardown("teardown0", func(ctx context.Context, t feature.T) {
 		require.Equal(t, int32(3), atomic.LoadInt32(&counter))
 	})
 	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
@@ -77,7 +77,7 @@ func TestTimingConstraints(t *testing.T) {
 }
 
 func appender(stringBuilder *strings.Builder, val string) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		stringBuilder.WriteString(val)
 	}
 }

--- a/test/example/config/echo/echo.go
+++ b/test/example/config/echo/echo.go
@@ -18,7 +18,6 @@ package echo
 
 import (
 	"context"
-	"testing"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -36,7 +35,7 @@ type Output struct {
 }
 
 func Install(message string) feature.StepFn {
-	return func(ctx context.Context, t *testing.T) {
+	return func(ctx context.Context, t feature.T) {
 		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{
 			"message": message,
 		}); err != nil {

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -35,10 +35,11 @@ func EchoFeature() *feature.Feature {
 	msg := fmt.Sprintf("hello %s", uuid.New())
 
 	f := new(feature.Feature)
+	f.Name = "Echo"
 
 	f.Setup("install echo", echo.Install(msg))
 
-	f.Requirement("echo job is finished", func(ctx context.Context, t *testing.T) {
+	f.Requirement("echo job is finished", func(ctx context.Context, t feature.T) {
 		env := environment.FromContext(ctx)
 		client := kubeclient.Get(ctx)
 
@@ -49,7 +50,7 @@ func EchoFeature() *feature.Feature {
 
 	f.Alpha("pull logs off a pod").
 		Must("the echo pod must echo our message",
-			func(ctx context.Context, t *testing.T) {
+			func(ctx context.Context, t feature.T) {
 				env := environment.FromContext(ctx)
 				client := kubeclient.Get(ctx)
 
@@ -75,10 +76,10 @@ func EchoFeature() *feature.Feature {
 				}
 				t.Log("got our message echo'ed: ", out.Message)
 			}).
-		May("An example of a MAY", func(ctx context.Context, t *testing.T) {
+		May("An example of a MAY", func(ctx context.Context, t feature.T) {
 			t.Log("ran inside of a MAY")
 		}).
-		Should("An example of a SHOULD", func(ctx context.Context, t *testing.T) {
+		Should("An example of a SHOULD", func(ctx context.Context, t feature.T) {
 			t.Log("ran inside of a SHOULD")
 		})
 

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -43,6 +43,8 @@ func EchoFeature() *feature.Feature {
 		env := environment.FromContext(ctx)
 		client := kubeclient.Get(ctx)
 
+		t.Fatal("I wanna fail")
+
 		if err := k8s.WaitUntilJobDone(client, env.Namespace(), "echo", time.Second, 30*time.Second); err != nil {
 			t.Errorf("failed to wait for job to finish, %s", err)
 		}

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -43,8 +43,6 @@ func EchoFeature() *feature.Feature {
 		env := environment.FromContext(ctx)
 		client := kubeclient.Get(ctx)
 
-		t.Fatal("I wanna fail")
-
 		if err := k8s.WaitUntilJobDone(client, env.Namespace(), "echo", time.Second, 30*time.Second); err != nil {
 			t.Errorf("failed to wait for job to finish, %s", err)
 		}

--- a/test/example/ko_publish_test.go
+++ b/test/example/ko_publish_test.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	_ "knative.dev/pkg/system/testing"
+
 	"knative.dev/reconciler-test/pkg/environment"
 )
 

--- a/test/example/recorder_feature.go
+++ b/test/example/recorder_feature.go
@@ -37,6 +37,7 @@ func RecorderFeature() *feature.Feature {
 	to := feature.MakeRandomK8sName("recorder")
 
 	f := new(feature.Feature)
+	f.Name = "Recorder"
 
 	event := FullEvent()
 


### PR DESCRIPTION
This PR revisits the way tests are executed and introduces some constraint on what can be executed inside the `StepFn`.

## The `feature.T` interface

The most important (and breaking) change is the `feature.T` interface. A `StepFn` now can fail, err, skip and log but it cannot create a subtest nor do other fancy stuff. This constrain a bit the step capabilities, in order to "force" users to create different feature steps. This also simplifies the assumptions we can do on whether happens in a step fn and allows us to record the stepfn results independently from what go testing is doing.

## The new step fn execution

Now the step fn (you can check it out in `magic.go`) doesn't run anymore in `t.Run`, but we manually run the stepFn in a specific goroutine that makes sure:

* context is properly handled per step-fn
* steps are executed in order
* one step fn cannot influence the execution of other step fn

I believe this approach gives us greater flexibility (e.g. we might have a policy that allows a test to not fail, after a feature step fails) and removes some race conditions (like https://github.com/knative/eventing/issues/4637 and the https://github.com/knative-sandbox/reconciler-test/pull/52).

To make sure our infra understands the results, I've adapted the output to the go test output. We could also work on a different "test results output format" in future that better adapts to our needs. E.g. we could output some "table" of features and, for each feature, what's the "reached" compliance level. Example: I have the retry feature, and say there is a SHOULD and a MUST. I want in output some "table" that tells me "your component retry feature compliance is at level MUST", even better it would be nice to save it in some file where I/the CI can grab it and process it.
