### PR TITLE
Adding FeatureSet and TestSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,41 @@ env := environment.FromContext(ctx)
 This returns the [`Environment`](./pkg/environment/interfaces.go) the feature is
 being tested in.
 
+#### Feature Sets
+
+Sometimes it makes sense to be able to provide a set of Features all at once. We
+call these "Feature Sets". They are intended to allow upstreams to bundle sets
+of features together to provide a simple low code way to vender and run a
+collection of Features together. `Test` and `TestSet` can be used together on an
+environment.
+
+```go
+ctx, env := global.Environment(/* optional environment options */)
+
+// With the instance of an Environment, perform one or more calls to Test().
+env.Test(ctx, t, FooFeature1())
+// Note: env.TestSet() is blocking until all features complete.
+env.TestSet(ctx, t, FooFeatureSet1())
+
+env.Finish()
+```
+
+##### Composing Feature Sets
+
+A `feature.FeatureSet` is implemented as a simple wrapper for a list of
+feature.Features, with a name for context.
+
+```go
+fs := &feature.FeatureSet{
+    Name:     "Some higher order idea",
+    Features: []feature.Feature{
+        *OneAspectFeature(),
+        *AnotherAspectFeature(),
+        *OptionalAspectFeature(),
+    },
+}
+```
+
 ##### YAML Setup Helpers
 
 The testing framework also enables YAML based installing of components. This

--- a/pkg/environment/interfaces.go
+++ b/pkg/environment/interfaces.go
@@ -44,11 +44,15 @@ type Environment interface {
 	// Test will execute the feature test using the given Context and T.
 	Test(ctx context.Context, t *testing.T, f *feature.Feature)
 
+	// TestSet will execute the feature set using the given Context and T.
+	TestSet(ctx context.Context, t *testing.T, fs *feature.FeatureSet)
+
 	// Namespace returns the namespace of this environment.
 	Namespace() string
 
 	// RequirementLevel returns the requirement level for this environment.
 	RequirementLevel() feature.Levels
+
 	// FeatureState returns the requirement level for this environment.
 	FeatureState() feature.States
 
@@ -57,6 +61,7 @@ type Environment interface {
 	// The map will be in the form `key`: `image` and `key` and the intention
 	// usage is to use this key to string substitute for image in test yaml.
 	Images() map[string]string
+
 	// TemplateConfig returns the base template config to use when processing
 	// yaml templates.
 	TemplateConfig(base map[string]interface{}) map[string]interface{}

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -184,11 +184,12 @@ func (mr *MagicEnvironment) TestSet(ctx context.Context, t *testing.T, fs *featu
 
 	// do it the slow way first.
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
 
 	for _, f := range fs.Features {
+		wg.Add(1)
 		t.Run(fs.Name, func(t *testing.T) {
 			mr.Test(ctx, t, &f)
+			wg.Done()
 		})
 	}
 

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -64,7 +64,9 @@ func (mr *MagicEnvironment) References() []corev1.ObjectReference {
 }
 
 func (mr *MagicEnvironment) Finish() {
-	mr.DeleteNamespaceIfNeeded()
+	if err := mr.DeleteNamespaceIfNeeded(); err != nil {
+		panic(err)
+	}
 }
 
 func (mr *MagicGlobalEnvironment) Environment(opts ...EnvOpts) (context.Context, Environment) {
@@ -136,7 +138,6 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 	steps := feature.CollapseSteps(f.Steps)
 
 	for _, timing := range feature.Timings() {
-		// do it the slow way first.
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -180,14 +181,13 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 
 // TestSet implements Environment.TestSet
 func (mr *MagicEnvironment) TestSet(ctx context.Context, t *testing.T, fs *feature.FeatureSet) {
-	t.Helper() // Helper marks the calling function as a test helper function.
-
-	// do it the slow way first.
+	t.Helper() // Helper marks the calling function as a test helper function
 	wg := &sync.WaitGroup{}
 
 	for _, f := range fs.Features {
 		wg.Add(1)
 		t.Run(fs.Name, func(t *testing.T) {
+			// FeatureSets should be run in parellel.
 			mr.Test(ctx, t, &f)
 			wg.Done()
 		})

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -178,6 +178,23 @@ func (mr *MagicEnvironment) Test(ctx context.Context, t *testing.T, f *feature.F
 	}
 }
 
+// TestSet implements Environment.TestSet
+func (mr *MagicEnvironment) TestSet(ctx context.Context, t *testing.T, fs *feature.FeatureSet) {
+	t.Helper() // Helper marks the calling function as a test helper function.
+
+	// do it the slow way first.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	for _, f := range fs.Features {
+		t.Run(fs.Name, func(t *testing.T) {
+			mr.Test(ctx, t, &f)
+		})
+	}
+
+	wg.Wait()
+}
+
 type envKey struct{}
 
 func ContextWith(ctx context.Context, e Environment) context.Context {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -28,6 +28,12 @@ type Feature struct {
 	Steps []Step
 }
 
+// FeatureSet is a list of features and feature set name.
+type FeatureSet struct {
+	Name  string
+	Features []Feature
+}
+
 // StepFn is the function signature for steps.
 type StepFn func(ctx context.Context, t *testing.T)
 

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -30,7 +30,7 @@ type Feature struct {
 
 // FeatureSet is a list of features and feature set name.
 type FeatureSet struct {
-	Name  string
+	Name     string
 	Features []Feature
 }
 

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -36,6 +36,7 @@ func TestTimingConstraints(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment()
+	defer env.Finish()
 
 	// We assert at the end on this string
 	stringBuilder := &strings.Builder{}

--- a/test/example/config/echo/echo.go
+++ b/test/example/config/echo/echo.go
@@ -35,9 +35,10 @@ type Output struct {
 	Message string `json:"msg"`
 }
 
-func Install(message string) feature.StepFn {
+func Install(name, message string) feature.StepFn {
 	return func(ctx context.Context, t *testing.T) {
 		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{
+			"name":    name,
 			"message": message,
 		}); err != nil {
 			t.Fatal(err)

--- a/test/example/config/echo/echo.yaml
+++ b/test/example/config/echo/echo.yaml
@@ -15,7 +15,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: echo
+  name: {{ .name }}
   namespace: {{ .namespace }}
 spec:
   backoffLimit: 0

--- a/test/example/config/echo/echo_test.go
+++ b/test/example/config/echo/echo_test.go
@@ -27,6 +27,7 @@ func Example() {
 		"ko://knative.dev/reconciler-test/test/example/cmd/echo": "uri://a-real-container",
 	}
 	cfg := map[string]interface{}{
+		"name":      "echo-123",
 		"namespace": "example",
 		"message":   "Hello, World!",
 	}
@@ -41,7 +42,7 @@ func Example() {
 	// apiVersion: batch/v1
 	// kind: Job
 	// metadata:
-	//   name: echo
+	//   name: echo-123
 	//   namespace: example
 	// spec:
 	//   backoffLimit: 0

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -32,17 +32,18 @@ import (
 )
 
 func EchoFeature() *feature.Feature {
-	msg := fmt.Sprintf("hello %s", uuid.New())
-
 	f := new(feature.Feature)
 
-	f.Setup("install echo", echo.Install(msg))
+	msg := fmt.Sprintf("hello %s", uuid.New())
+	name := "echo" + uuid.New().String()
+
+	f.Setup("install echo", echo.Install(name, msg))
 
 	f.Requirement("echo job is finished", func(ctx context.Context, t *testing.T) {
 		env := environment.FromContext(ctx)
 		client := kubeclient.Get(ctx)
 
-		if err := k8s.WaitUntilJobDone(client, env.Namespace(), "echo", time.Second, 30*time.Second); err != nil {
+		if err := k8s.WaitUntilJobDone(client, env.Namespace(), name, time.Second, 30*time.Second); err != nil {
 			t.Errorf("failed to wait for job to finish, %s", err)
 		}
 	})
@@ -53,7 +54,7 @@ func EchoFeature() *feature.Feature {
 				env := environment.FromContext(ctx)
 				client := kubeclient.Get(ctx)
 
-				log, err := k8s.WaitForJobTerminationMessage(client, env.Namespace(), "echo", time.Second, 30*time.Second)
+				log, err := k8s.WaitForJobTerminationMessage(client, env.Namespace(), name, time.Second, 30*time.Second)
 				if err != nil {
 					t.Error("failed to get termination message from pod, ", err)
 				}

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -88,7 +88,7 @@ func EchoFeature() *feature.Feature {
 // EchoFeatureSet makes a feature set out of a few EchoFeatures for testing.
 func EchoFeatureSet() *feature.FeatureSet {
 	fs := &feature.FeatureSet{
-		Name:     "Echo Feature Wrapper (3x)",
+		Name: "Echo Feature Wrapper (3x)",
 		Features: []feature.Feature{
 			*EchoFeature(),
 			*EchoFeature(),

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -84,3 +84,16 @@ func EchoFeature() *feature.Feature {
 
 	return f
 }
+
+// EchoFeatureSet makes a feature set out of a few EchoFeatures for testing.
+func EchoFeatureSet() *feature.FeatureSet {
+	fs := &feature.FeatureSet{
+		Name:     "Echo Feature Wrapper (3x)",
+		Features: []feature.Feature{
+			*EchoFeature(),
+			*EchoFeature(),
+			*EchoFeature(),
+		},
+	}
+	return fs
+}

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -76,3 +76,27 @@ func TestEcho(t *testing.T) {
 	// Calling finish on the environment cleans it up and removes the namespace.
 	env.Finish()
 }
+
+
+
+// TestEchoSet is an example simple test set.
+func TestEchoSet(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	// Create an environment to run the tests in from the global environment.
+	ctx, env := global.Environment()
+
+	fs := EchoFeatureSet()
+
+	// Now is the chance to modify the feature to add additional preconditions or assertions.
+
+	env.TestSet(ctx, t, fs)
+
+	// note: we can run other features in this environment if we understand the side-effects.
+	// env.Test(ctx, t, SomeOtherFeature())
+
+	// Calling finish on the environment cleans it up and removes the namespace.
+	env.Finish()
+}

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -77,8 +77,6 @@ func TestEcho(t *testing.T) {
 	env.Finish()
 }
 
-
-
 // TestEchoSet is an example simple test set.
 func TestEchoSet(t *testing.T) {
 	// Signal to the go test framework that this test can be run in parallel


### PR DESCRIPTION
# Changes

fixes https://github.com/knative-sandbox/reconciler-test/issues/65

- :gift: Adding FeatureSet, a wrapper around a set of features.
- :gift: Adding TestSet, a test entry point to run a FeatureSet.

/kind enhancement

We need a way to vendor a group of features rather than individuals, the aim here is to provide a set of features that might be required for something like a conformance test, and it does not make much sense to vendor them individually as a burden to the downstream user of these.

**Release Note**

```release-note
Adding feature.FeatureSet and Environment.TestSet.
```

