### PR TITLE
Added feature.Assert shortcut

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -105,6 +105,12 @@ func (f *Feature) Requirement(name string, fn StepFn) {
 	})
 }
 
+// Assert is a shortcut for Stable(name).Must(name, fn),
+// useful for developing integration tests that doesn't require assertion levels.
+func (f *Feature) Assert(name string, fn StepFn) {
+	f.Stable(name).Must(name, fn)
+}
+
 // Assert adds a step function to the feature set at the Assert timing phase.
 func (a *Asserter) Assert(l Levels, name string, fn StepFn) {
 	a.f.AddStep(Step{


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Because when developing e2e/integration tests the user doesn't care about the compliance levels, this PR adds a `feature.Assert` which defaults to the highest level and state 

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `feature.Assert` for e2e tests developers