### PR TITLE
More refactoring for the execution

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -1,6 +1,12 @@
 package environment
 
-import "knative.dev/reconciler-test/pkg/feature"
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/feature"
+)
 
 func categorizeSteps(steps []feature.Step) map[feature.Timing][]feature.Step {
 	res := make(map[feature.Timing][]feature.Step, 4)
@@ -21,4 +27,46 @@ func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.St
 		}
 	}
 	return res
+}
+
+func (mr *MagicEnvironment) executeWithSkippingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
+	return mr.executeStep(ctx, originalT, f, s, createSkippingT)
+}
+
+func (mr *MagicEnvironment) executeWithSubT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
+	return mr.executeStep(ctx, originalT, f, s, func(t *testing.T) feature.T {
+		return t
+	})
+}
+
+func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) feature.T {
+	ctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	var internalT feature.T
+	originalT.Run(s.T.String()+"/"+s.TestName(), func(st *testing.T) {
+		st.Helper()
+		internalT = tDecorator(st)
+		st.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
+
+		// Create a cancel tied to this step
+		ctx, cancelFn := context.WithCancel(ctx)
+		st.Cleanup(cancelFn)
+
+		mr.milestoneEmitter.StepStarted(f.Name, s, internalT)
+		originalT.Cleanup(func() {
+			mr.milestoneEmitter.StepFinished(f.Name, s, internalT)
+		})
+
+		// Perform step.
+		s.Fn(ctx, internalT)
+	})
+
+	// Wait for the test to execute before spawning the next one
+	wg.Wait()
+
+	return internalT
 }

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -56,9 +56,9 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 		ctx, cancelFn := context.WithCancel(ctx)
 		st.Cleanup(cancelFn)
 
-		mr.milestoneEmitter.StepStarted(f.Name, s, internalT)
+		mr.milestones.StepStarted(f.Name, s, internalT)
 		originalT.Cleanup(func() {
-			mr.milestoneEmitter.StepFinished(f.Name, s, internalT)
+			mr.milestones.StepFinished(f.Name, s, internalT)
 		})
 
 		// Perform step.

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -29,17 +29,22 @@ func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.St
 	return res
 }
 
+// executeWithSkippingT executes the step in a sub test wrapping t in order to never fail the subtest
 func (mr *MagicEnvironment) executeWithSkippingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
+	originalT.Helper()
 	return mr.executeStep(ctx, originalT, f, s, createSkippingT)
 }
 
-func (mr *MagicEnvironment) executeWithSubT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
+// executeWithoutWrappingT executes the step in a sub test without wrapping t
+func (mr *MagicEnvironment) executeWithoutWrappingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
+	originalT.Helper()
 	return mr.executeStep(ctx, originalT, f, s, func(t *testing.T) feature.T {
 		return t
 	})
 }
 
 func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) feature.T {
+	originalT.Helper()
 	ctx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -198,7 +198,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 		s := s
 
 		// Setup are executed always, no matter their level and state
-		internalT := mr.executeWithSubT(ctx, originalT, f, &s)
+		internalT := mr.executeWithoutWrappingT(ctx, originalT, f, &s)
 
 		// Failed setup fails everything, so just run the teardown
 		if internalT.Failed() {
@@ -232,7 +232,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 		}
 
 		if mr.shouldFail(&s) {
-			mr.executeWithSubT(ctx, originalT, f, &s)
+			mr.executeWithoutWrappingT(ctx, originalT, f, &s)
 		} else {
 			mr.executeWithSkippingT(ctx, originalT, f, &s)
 		}
@@ -247,7 +247,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 		wg.Add(1)
 
 		// Teardown are executed always, no matter their level and state
-		mr.executeWithSubT(ctx, originalT, f, &s)
+		mr.executeWithoutWrappingT(ctx, originalT, f, &s)
 	}
 
 	if skipReason != "" {

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -52,7 +52,7 @@ func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {
 			return fmt.Errorf("failed to create Namespace: %s; %v", mr.namespace, err)
 		}
 		mr.namespaceCreated = true
-		mr.milestoneEmitter.NamespaceCreated(mr.namespace)
+		mr.milestones.NamespaceCreated(mr.namespace)
 
 		// https://github.com/kubernetes/kubernetes/issues/66689
 		// We can only start creating pods after the default ServiceAccount is created by the kube-controller-manager.
@@ -85,7 +85,7 @@ func (mr *MagicEnvironment) DeleteNamespaceIfNeeded() error {
 			return err
 		}
 		mr.namespaceCreated = false
-		mr.milestoneEmitter.NamespaceDeleted(mr.namespace)
+		mr.milestones.NamespaceDeleted(mr.namespace)
 	}
 
 	return nil

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -52,7 +52,7 @@ func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {
 			return fmt.Errorf("failed to create Namespace: %s; %v", mr.namespace, err)
 		}
 		mr.namespaceCreated = true
-		mr.milestones.NamespaceCreated(mr.namespace)
+		mr.milestoneEmitter.NamespaceCreated(mr.namespace)
 
 		// https://github.com/kubernetes/kubernetes/issues/66689
 		// We can only start creating pods after the default ServiceAccount is created by the kube-controller-manager.
@@ -85,7 +85,7 @@ func (mr *MagicEnvironment) DeleteNamespaceIfNeeded() error {
 			return err
 		}
 		mr.namespaceCreated = false
-		mr.milestones.NamespaceDeleted(mr.namespace)
+		mr.milestoneEmitter.NamespaceDeleted(mr.namespace)
 	}
 
 	return nil

--- a/pkg/environment/t.go
+++ b/pkg/environment/t.go
@@ -8,95 +8,95 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-// requirementT records if the test succeeded or failing, but never fails it in order to avoid bad reporting
-type requirementT struct {
+// skippingT records if the test succeeded or failing, but never fails it
+type skippingT struct {
 	*testing.T
 
 	failed  *atomic.Bool
 	skipped *atomic.Bool
 }
 
-var _ feature.T = (*requirementT)(nil)
+var _ feature.T = (*skippingT)(nil)
 
-func createRequirementT(originalT *testing.T) *requirementT {
-	return &requirementT{
+func createSkippingT(originalT *testing.T) feature.T {
+	return &skippingT{
 		T:       originalT,
 		failed:  atomic.NewBool(false),
 		skipped: atomic.NewBool(false),
 	}
 }
 
-func (t *requirementT) Error(args ...interface{}) {
+func (t *skippingT) Error(args ...interface{}) {
 	t.T.Helper()
 	t.failed.Store(true)
 	t.T.Log(args...)
 }
 
-func (t *requirementT) Errorf(format string, args ...interface{}) {
+func (t *skippingT) Errorf(format string, args ...interface{}) {
 	t.T.Helper()
 	t.failed.Store(true)
 	t.T.Logf(format, args...)
 }
 
-func (t *requirementT) Fail() {
+func (t *skippingT) Fail() {
 	t.T.Helper()
 	t.failed.Store(true)
 }
 
-func (t *requirementT) FailNow() {
+func (t *skippingT) FailNow() {
 	t.T.Helper()
 	t.failed.Store(true)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) Failed() bool {
+func (t *skippingT) Failed() bool {
 	return t.failed.Load()
 }
 
-func (t *requirementT) Fatal(args ...interface{}) {
+func (t *skippingT) Fatal(args ...interface{}) {
 	t.T.Helper()
 	t.failed.Store(true)
 	t.T.Log(args...)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) Fatalf(format string, args ...interface{}) {
+func (t *skippingT) Fatalf(format string, args ...interface{}) {
 	t.T.Helper()
 	t.failed.Store(true)
 	t.T.Logf(format, args...)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) Log(args ...interface{}) {
+func (t *skippingT) Log(args ...interface{}) {
 	t.T.Helper()
 	t.T.Log(args...)
 }
 
-func (t *requirementT) Logf(format string, args ...interface{}) {
+func (t *skippingT) Logf(format string, args ...interface{}) {
 	t.T.Helper()
 	t.T.Logf(format, args...)
 }
 
-func (t *requirementT) Skip(args ...interface{}) {
+func (t *skippingT) Skip(args ...interface{}) {
 	t.T.Helper()
 	t.skipped.Store(true)
 	t.T.Log(args...)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) Skipf(format string, args ...interface{}) {
+func (t *skippingT) Skipf(format string, args ...interface{}) {
 	t.T.Helper()
 	t.skipped.Store(true)
 	t.T.Logf(format, args...)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) SkipNow() {
+func (t *skippingT) SkipNow() {
 	t.T.Helper()
 	t.skipped.Store(true)
 	t.T.SkipNow()
 }
 
-func (t *requirementT) Skipped() bool {
+func (t *skippingT) Skipped() bool {
 	return t.skipped.Load()
 }

--- a/pkg/feature/t.go
+++ b/pkg/feature/t.go
@@ -16,25 +16,31 @@ limitations under the License.
 
 package feature
 
+import "time"
+
 // T is an interface similar to testing.T passed to StepFn to perform logging and assertions
 type T interface {
 	Name() string
 
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
-
 	Fail()
-	FailNow()
-	Failed() bool
 
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
-
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
+	FailNow()
 
 	Skip(args ...interface{})
 	Skipf(format string, args ...interface{})
 	SkipNow()
+
+	Failed() bool
 	Skipped() bool
+
+	// Note: these are step scoped!
+	Cleanup(f func())
+	Deadline() (deadline time.Time, ok bool)
 }

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -32,53 +32,6 @@ import (
 
 // These are example tests that fail intentionally to demonstrate feature timings working.
 
-func TestRequirementSkip(t *testing.T) {
-	// Signal to the go test framework that this test can be run in parallel
-	// with other tests.
-	t.Parallel()
-
-	ctx, env := global.Environment()
-
-	// We assert at the end on this string
-	stringBuilder := &strings.Builder{}
-
-	// Build the feature
-	feat := &feature.Feature{}
-
-	counter := int32(0)
-
-	feat.Setup("setup1", appender(stringBuilder, "setup1"))
-	feat.Setup("setup2", appender(stringBuilder, "setup2"))
-	feat.Setup("setup3", appender(stringBuilder, "setup3"))
-	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
-	feat.Requirement("requirement2", func(ctx context.Context, t feature.T) {
-		t.Fatalf("We can't fulfill this requirement")
-		appender(stringBuilder, "requirement2")
-	})
-	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
-	feat.Stable("A cool feature").
-		Must("aaa", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		}).
-		Must("bbb", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		}).
-		Must("ccc", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		})
-	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
-	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
-	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
-
-	env.Test(ctx, t, feat)
-
-	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
-	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
-}
-
 // This should fail because a setup phase failed
 func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 	// Signal to the go test framework that this test can be run in parallel

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -41,7 +41,7 @@ func TestTimingConstraints(t *testing.T) {
 	stringBuilder := &strings.Builder{}
 
 	// Build the feature
-	feat := &feature.Feature{Name: "TestTimingConstraints"}
+	feat := feature.NewFeature()
 
 	counter := int32(0)
 
@@ -74,6 +74,55 @@ func TestTimingConstraints(t *testing.T) {
 	env.Test(ctx, t, feat)
 
 	require.Equal(t, "setup1setup2setup3requirement1requirement2requirement3teardown1teardown2teardown3", stringBuilder.String())
+
+	env.Finish()
+}
+
+func TestRequirementSkip(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment()
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := feature.NewFeature()
+
+	counter := int32(0)
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", appender(stringBuilder, "setup2"))
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
+	feat.Requirement("requirement2", func(ctx context.Context, t feature.T) {
+		t.Fatalf("We can't fulfill this requirement")
+		appender(stringBuilder, "requirement2")
+	})
+	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
+	feat.Stable("A cool feature").
+		Must("aaa", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("bbb", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("ccc", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		})
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
+	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
 
 	env.Finish()
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Now all asserts are executed, no matter their level, but the ones not required by the input flags (https://github.com/knative-sandbox/reconciler-test/pull/119/files#diff-36dc7755231472dee1b65e70532635dce8e7d0edcfec67c9db7b1d8c0307998dR258) won't fail the test. Thanks to this, we can do true conformance testing, running all the tests but passing the suite only if a certain level is reached (in #118 I discuss how we could implement the reporting for that)
- :gift: Introduce `Deadline` and `Cleanup` in `feature.T`
- :broom: Renamed `requirementT` to `skippingT` to highlight its behaviour
- :bug: Fix again the context issue, which was mistakenly reintroduce in #112
- :broom: Some names cleanup and things moved
- :bug: Fix https://github.com/knative-sandbox/reconciler-test/pull/116#discussion_r589974641
