### PR TITLE
auto manage lifecycle of env

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,20 +92,20 @@ func TestFoo(t *testing.T) {
 
 	// Create an instance of an environment. The environment will be configured
 	// with any relevant configuration and settings based on the global
-	// environment settings. Additional options can be passed to Environment()
-	// if customization is required.
-	ctx, env := global.Environment(/* optional environment options */)
+	// environment settings. Using environment.Managed(t) will call env.Finish()
+	// on test completion. If this option is not used, the test should call
+	// env.Finish() to perform cleanup at the end of the test. Additional options
+	// can be passed to Environment() if customization is required.
+	ctx, env := global.Environment(environment.Managed(t) /*, optional environment options */)
 
 	// With the instance of an Environment, perform one or more calls to Test().
 	env.Test(ctx, t, FooFeature1())
 	// Note: env.Test() is blocking until the feature completes.
     env.Test(ctx, t, FooFeature2())
-
-	// Call Finish() on the Environment when finished. This will clean up any
-	// ephemeral resources created from global.Environment() and env.Test().
-	env.Finish()
 }
 ```
+
+
 
 The role of the `Test<Name>` methods is to control which features are tested on
 environment instances. It is your responsibility to understand if it is safe to
@@ -224,14 +224,12 @@ collection of Features together. `Test` and `TestSet` can be used together on an
 environment.
 
 ```go
-ctx, env := global.Environment(/* optional environment options */)
+ctx, env := global.Environment(environment.Managed(t) /*, optional environment options */)
 
 // With the instance of an Environment, perform one or more calls to Test().
 env.Test(ctx, t, FooFeature1())
 // Note: env.TestSet() is blocking until all features complete.
 env.TestSet(ctx, t, FooFeatureSet1())
-
-env.Finish()
 ```
 
 ##### Composing Feature Sets

--- a/README.md
+++ b/README.md
@@ -99,13 +99,11 @@ func TestFoo(t *testing.T) {
 	ctx, env := global.Environment(environment.Managed(t) /*, optional environment options */)
 
 	// With the instance of an Environment, perform one or more calls to Test().
-	env.Test(ctx, t, FooFeature1())
 	// Note: env.Test() is blocking until the feature completes.
+	env.Test(ctx, t, FooFeature1())
 	env.Test(ctx, t, FooFeature2())
 }
 ```
-
-
 
 The role of the `Test<Name>` methods is to control which features are tested on
 environment instances. It is your responsibility to understand if it is safe to

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ func TestFoo(t *testing.T) {
 	// With the instance of an Environment, perform one or more calls to Test().
 	env.Test(ctx, t, FooFeature1())
 	// Note: env.Test() is blocking until the feature completes.
-    env.Test(ctx, t, FooFeature2())
+	env.Test(ctx, t, FooFeature2())
 }
 ```
 

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -87,6 +87,15 @@ func (mr *MagicEnvironment) Finish() {
 	mr.milestones.Finished()
 }
 
+// Managed enables auto-lifecycle management of the environment. Including:
+//  - registers a t.Cleanup callback on env.Finish().
+func Managed(t feature.T) EnvOpts {
+	return func(ctx context.Context, env Environment) (context.Context, error) {
+		t.Cleanup(env.Finish)
+		return ctx, nil
+	}
+}
+
 func (mr *MagicGlobalEnvironment) Environment(opts ...EnvOpts) (context.Context, Environment) {
 	images, err := ProduceImages()
 	if err != nil {

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"context"
-	"knative.dev/reconciler-test/pkg/environment"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
 

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"knative.dev/reconciler-test/pkg/environment"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -38,7 +39,7 @@ func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 	// with other tests.
 	t.Parallel()
 
-	ctx, env := global.Environment()
+	ctx, env := global.Environment(environment.Managed(t))
 
 	// We assert at the end on this string
 	stringBuilder := &strings.Builder{}

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"context"
-	"knative.dev/reconciler-test/pkg/environment"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
 

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"knative.dev/reconciler-test/pkg/environment"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -35,7 +36,7 @@ func TestTimingConstraints(t *testing.T) {
 	// with other tests.
 	t.Parallel()
 
-	ctx, env := global.Environment()
+	ctx, env := global.Environment(environment.Managed(t))
 
 	// We assert at the end on this string
 	stringBuilder := &strings.Builder{}
@@ -74,8 +75,6 @@ func TestTimingConstraints(t *testing.T) {
 	env.Test(ctx, t, feat)
 
 	require.Equal(t, "setup1setup2setup3requirement1requirement2requirement3teardown1teardown2teardown3", stringBuilder.String())
-
-	env.Finish()
 }
 
 func TestRequirementSkip(t *testing.T) {
@@ -83,7 +82,7 @@ func TestRequirementSkip(t *testing.T) {
 	// with other tests.
 	t.Parallel()
 
-	ctx, env := global.Environment()
+	ctx, env := global.Environment(environment.Managed(t))
 
 	// We assert at the end on this string
 	stringBuilder := &strings.Builder{}
@@ -123,8 +122,6 @@ func TestRequirementSkip(t *testing.T) {
 
 	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
-
-	env.Finish()
 }
 
 func appender(stringBuilder *strings.Builder, val string) feature.StepFn {

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package example
 
 import (
+	"knative.dev/reconciler-test/pkg/environment"
 	"testing"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -41,6 +42,7 @@ func TestRecorder(t *testing.T) {
 	// environment settings. Additional options can be passed to Environment()
 	// if customization is required.
 	ctx, env := global.Environment(
+		environment.Managed(t), // Will call env.Finish() when the test exits.
 		knative.WithKnativeNamespace("knative-reconciler-test"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
@@ -49,10 +51,6 @@ func TestRecorder(t *testing.T) {
 
 	// With the instance of an Environment, perform one or more calls to Test().
 	env.Test(ctx, t, RecorderFeature())
-
-	// Call Finish() on the Environment when finished. This will clean up any
-	// ephemeral resources created from global.Environment() and env.Test().
-	env.Finish()
 }
 
 // TestEcho is an example simple test.
@@ -62,7 +60,7 @@ func TestEcho(t *testing.T) {
 	t.Parallel()
 
 	// Create an environment to run the tests in from the global environment.
-	ctx, env := global.Environment()
+	ctx, env := global.Environment(environment.Managed(t))
 
 	f := EchoFeature()
 
@@ -72,9 +70,6 @@ func TestEcho(t *testing.T) {
 
 	// note: we can run other features in this environment if we understand the side-effects.
 	// env.Test(ctx, t, SomeOtherFeature())
-
-	// Calling finish on the environment cleans it up and removes the namespace.
-	env.Finish()
 }
 
 // TestEchoSet is an example simple test set.
@@ -84,7 +79,7 @@ func TestEchoSet(t *testing.T) {
 	t.Parallel()
 
 	// Create an environment to run the tests in from the global environment.
-	ctx, env := global.Environment()
+	ctx, env := global.Environment(environment.Managed(t))
 
 	fs := EchoFeatureSet()
 
@@ -94,7 +89,4 @@ func TestEchoSet(t *testing.T) {
 
 	// note: we can run other features in this environment if we understand the side-effects.
 	// env.Test(ctx, t, SomeOtherFeature())
-
-	// Calling finish on the environment cleans it up and removes the namespace.
-	env.Finish()
 }

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package example
 
 import (
-	"knative.dev/reconciler-test/pkg/environment"
 	"testing"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -27,6 +26,7 @@ import (
 
 	_ "knative.dev/pkg/system/testing"
 
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 )


### PR DESCRIPTION
fixes https://github.com/knative-sandbox/reconciler-test/issues/40

We provide a hook to allow a user to opt into a managed environment, they are free to not use this option and call `env.Finish()` directly. 

This is a non-API breaking change.