### PR TITLE
don't use panics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ func Install(message string) feature.StepFn {
 	}
 	return func(ctx context.Context, t *testing.T) {
 		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ func Install(message string) feature.StepFn {
 	}
 	return func(ctx context.Context, t *testing.T) {
 		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	}
 }

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -47,7 +47,8 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		// Compute the user provided envs
 		envs := make(map[string]string)
 		if err := compose(options...)(ctx, envs); err != nil {
-			t.Fatalf("Error while computing environment variables for eventshub: %s", err)
+			t.Errorf("Error while computing environment variables for eventshub: %s", err)
+			return
 		}
 
 		// eventshub needs tracing and logging config
@@ -59,7 +60,8 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			"name": name,
 			"envs": envs,
 		}); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		k8s.WaitForPodRunningOrFail(ctx, t, name)

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -112,7 +112,7 @@ func WaitForResourceReady(ctx context.Context, namespace, name string, gvr schem
 		}
 		obj := like.DeepCopy()
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(us.Object, obj); err != nil {
-			log.Fatalf("Error DefaultUnstructuree.Dynamiconverter. %v", err)
+			return false, err
 		}
 		obj.ResourceVersion = gvr.Version
 		obj.APIVersion = gvr.GroupVersion().String()
@@ -159,14 +159,14 @@ func WaitForResourceReady(ctx context.Context, namespace, name string, gvr schem
 // WaitForServiceEndpointsOrFail wraps the utility from pkg and uses the context to extract kubeclient and namespace
 func WaitForServiceEndpointsOrFail(ctx context.Context, t feature.T, svcName string, numberOfExpectedEndpoints int) {
 	if err := pkgtest.WaitForServiceEndpoints(ctx, kubeclient.Get(ctx), svcName, environment.FromContext(ctx).Namespace(), numberOfExpectedEndpoints); err != nil {
-		t.Fatalf("Failed while waiting for %d endpoints in service %s: %+v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
+		t.Errorf("Failed while waiting for %d endpoints in service %s: %+v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
 	}
 }
 
 // WaitForPodRunningOrFail wraps the utility from pkg and uses the context to extract kubeclient and namespace
 func WaitForPodRunningOrFail(ctx context.Context, t feature.T, podName string) {
 	if err := pkgtest.WaitForPodRunning(ctx, kubeclient.Get(ctx), podName, environment.FromContext(ctx).Namespace()); err != nil {
-		t.Fatalf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err))
+		t.Errorf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err))
 	}
 }
 

--- a/test/example/config/echo/echo.go
+++ b/test/example/config/echo/echo.go
@@ -40,7 +40,7 @@ func Install(name, message string) feature.StepFn {
 			"name":    name,
 			"message": message,
 		}); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 }


### PR DESCRIPTION
Too many of these errors:

```
    --- FAIL: TestBrokerDirect/Assert/[Alpha/MUST]RabbitMQ_source_the_recorder_received_all_sent_events_within_the_time (240.00s)
panic: Fail in goroutine after TestBrokerDirect/Setup/install_recorder has completed [recovered]
	panic: Fail in goroutine after TestBrokerDirect/Setup/install_recorder has completed
```