### PR TITLE
[eventshub] Define the method to send http requests and drop events

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -30,6 +30,7 @@ import (
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/test_images/eventshub/dropevents"
 )
 
 // EventsHubOption is used to define an env for the eventshub image
@@ -101,6 +102,17 @@ func ResponseWaitTime(delay time.Duration) EventsHubOption {
 	return envDuration("RESPONSE_WAIT_TIME", delay)
 }
 
+// FibonacciDrop will cause the receiver to reply with a bad status code following the fibonacci sequence
+var FibonacciDrop = envOption("SKIP_ALGORITHM", dropevents.Fibonacci)
+
+// DropFirstN will cause the receiver to reply with a bad status code to the first n events
+func DropFirstN(n uint) EventsHubOption {
+	return compose(
+		envOption("SKIP_ALGORITHM", dropevents.Sequence),
+		envOption("SKIP_COUNTER", strconv.FormatUint(uint64(n), 10)),
+	)
+}
+
 // --- Sender options
 
 // InitialSenderDelay defines how much the sender has to wait, when started, before start sending events.
@@ -155,6 +167,11 @@ func InputHeader(k, v string) EventsHubOption {
 // InputBody overwrites the request header with the following body.
 func InputBody(b string) EventsHubOption {
 	return envOption("INPUT_BODY", b)
+}
+
+// InputMethod overrides which http method to use when sending events (default is POST)
+func InputMethod(method string) EventsHubOption {
+	return envOption("INPUT_METHOD", method)
 }
 
 // AddTracing adds tracing headers when sending events.

--- a/pkg/test_images/eventshub/receiver/receiver.go
+++ b/pkg/test_images/eventshub/receiver/receiver.go
@@ -105,7 +105,7 @@ func NewFromEnv(ctx context.Context, eventLogs *eventshub.EventLogs) *Receiver {
 	} else {
 		counter = &dropevents.CounterHandler{
 			// Don't skip anything, since count is 0. nop skipper.
-			Skipper: dropevents.SkipperAlgorithmWithCount(dropevents.Sequence, 0),
+			Skipper: dropevents.NoopSkipper,
 		}
 	}
 

--- a/pkg/test_images/eventshub/sender/sender.go
+++ b/pkg/test_images/eventshub/sender/sender.go
@@ -68,6 +68,9 @@ type envConfig struct {
 	// InputBody to send (this overrides any event provided input)
 	InputBody string `envconfig:"INPUT_BODY" required:"false"`
 
+	// InputMethod to use when sending the http request
+	InputMethod string `envconfig:"INPUT_METHOD" default:"POST" required:"false"`
+
 	// Should tracing be added to events sent.
 	AddTracing bool `envconfig:"ADD_TRACING" default:"false" required:"false"`
 
@@ -152,7 +155,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 
 	ticker := time.NewTicker(period)
 	for {
-		req, err := nethttp.NewRequest(nethttp.MethodPost, env.Sink, nil)
+		req, err := nethttp.NewRequest(env.InputMethod, env.Sink, nil)
 		if err != nil {
 			logging.FromContext(ctx).Error("Cannot create the request: ", err)
 			return err


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix  #99

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Added an option to define the input method
- Added an option to drop events (already implemented previously, it was just missing the options)