### PR TITLE
Now stepfn can panic safely

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -55,6 +55,11 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 	originalT.Run(s.T.String()+"/"+s.TestName(), func(st *testing.T) {
 		st.Helper()
 		internalT = tDecorator(st)
+		defer func() {
+			if r := recover(); r != nil {
+				internalT.Error("panic happened", r)
+			}
+		}()
 		st.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
 
 		// Create a cancel tied to this step

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -238,6 +238,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 		if internalT.Failed() {
 			skipAssertions = true
 			skipRequirements = true // No need to test other requirements
+			break                   // No need to continue the setup
 		}
 	}
 

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -53,7 +53,7 @@ func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 	feat.Setup("setup2", appender(stringBuilder, "setup2"))
 	feat.Setup("setup3", func(ctx context.Context, t feature.T) {
 		t.Fatalf("This setup failed")
-		appender(stringBuilder, "setup3")
+		appender(stringBuilder, "setup3")(ctx, t)
 	})
 	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
 	feat.Requirement("requirement2", appender(stringBuilder, "requirement2"))
@@ -79,4 +79,112 @@ func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 
 	require.Equal(t, "setup1setup2teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
+}
+
+// This should fail because a setup phase failed
+func TestPanicInSetupSkipsToTeardown(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment(environment.Managed(t))
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := &feature.Feature{}
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", func(ctx context.Context, t feature.T) {
+		panic("a bad one")
+	})
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1teardown1teardown2teardown3", stringBuilder.String())
+}
+
+func TestPanicContinuesTheExecutionOfAssertions(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment(environment.Managed(t))
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := &feature.Feature{}
+
+	counter := int32(0)
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", appender(stringBuilder, "setup2"))
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Stable("A cool feature").
+		Must("aaa", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("bbb", func(ctx context.Context, t feature.T) {
+			panic("something bad happened")
+		}).
+		Must("ccc", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		})
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1setup2setup3teardown1teardown2teardown3", stringBuilder.String())
+	require.Equal(t, int32(2), atomic.LoadInt32(&counter))
+}
+
+func TestFatalContinuesTheExecutionOfAssertions(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment(environment.Managed(t))
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := &feature.Feature{}
+
+	counter := int32(0)
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", appender(stringBuilder, "setup2"))
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Stable("A cool feature").
+		Must("aaa", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("bbb", func(ctx context.Context, t feature.T) {
+			t.Fatal("Yeah we broke something")
+		}).
+		Must("ccc", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		})
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1setup2setup3teardown1teardown2teardown3", stringBuilder.String())
+	require.Equal(t, int32(2), atomic.LoadInt32(&counter))
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #32 

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Now stepfn can panic. Handle panics and mark the test as failed without quitting the test process
- :broom: Added a test to check both panics and fatal
