### PR TITLE
Use test as prefix for test namespaces

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -111,7 +111,7 @@ func (mr *MagicGlobalEnvironment) Environment(opts ...EnvOpts) (context.Context,
 		panic(err)
 	}
 
-	namespace := feature.MakeK8sNamePrefix(feature.AppendRandomString("rekt"))
+	namespace := feature.MakeK8sNamePrefix(feature.AppendRandomString("test"))
 
 	env := &MagicEnvironment{
 		c:         mr.c,


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This allows the existing test infra to collect the logs https://github.com/knative/eventing/issues/5076

Also prefixing with `test` is more reasonable and easy to understand