### PR TITLE
[eventshub] Override time when sending events

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -167,6 +167,9 @@ var AddSequence = envOption("ADD_SEQUENCE", "true")
 // EnableIncrementalId replaces the event id with a new incremental id for each sent event.
 var EnableIncrementalId = envOption("INCREMENTAL_ID", "true")
 
+// OverrideTime overrides the event time with the time when sending the event.
+var OverrideTime = envOption("OVERRIDE_TIME", "true")
+
 // SendMultipleEvents defines how much events to send and the period between them.
 func SendMultipleEvents(numberOfEvents int, period time.Duration) EventsHubOption {
 	return compose(

--- a/pkg/test_images/eventshub/sender/sender.go
+++ b/pkg/test_images/eventshub/sender/sender.go
@@ -77,6 +77,9 @@ type envConfig struct {
 	// Override the event id with an incremental id.
 	IncrementalId bool `envconfig:"INCREMENTAL_ID" default:"false" required:"false"`
 
+	// Override the event time with the time when sending the event.
+	OverrideTime bool `envconfig:"OVERRIDE_TIME" default:"false" required:"false"`
+
 	// The number of seconds between messages.
 	Period int `envconfig:"PERIOD" default:"5" required:"false"`
 
@@ -169,6 +172,9 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 			}
 			if env.IncrementalId {
 				event.SetID(strconv.Itoa(sequence))
+			}
+			if env.OverrideTime {
+				event.SetTime(time.Now())
 			}
 
 			logging.FromContext(ctx).Info("I'm going to send\n", event)


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Add a new option to event sender to override the Time field of the event when sending