### PR TITLE
add id for correlation

### DIFF
--- a/pkg/test_images/eventshub/event_info.go
+++ b/pkg/test_images/eventshub/event_info.go
@@ -60,6 +60,10 @@ type EventInfo struct {
 	Observer string    `json:"observer,omitempty"`
 	Time     time.Time `json:"time,omitempty"`
 	Sequence uint64    `json:"sequence"`
+	// This is just a convenience / correlator. We take the ID of the sent event
+	// and in the Response also jot it down so you can correlate which event (ID)
+	// as well as sequence to match sent/response 1:1.
+	Id string `json:"id"`
 }
 
 // Pretty print the event. Meant for debugging.
@@ -96,6 +100,7 @@ func (ei *EventInfo) String() string {
 	sb.WriteString("--- Observer: '" + ei.Observer + "' ---\n")
 	sb.WriteString("--- Time: " + ei.Time.String() + " ---\n")
 	sb.WriteString(fmt.Sprintf("--- Sequence: %d ---\n", ei.Sequence))
+	sb.WriteString("--- Id:  '" + ei.Id + " ---\n")
 	sb.WriteString("--------------------\n")
 	return sb.String()
 }

--- a/pkg/test_images/eventshub/sender/sender.go
+++ b/pkg/test_images/eventshub/sender/sender.go
@@ -201,6 +201,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 				Observer: env.SenderName,
 				Time:     time.Now(),
 				Sequence: uint64(sequence),
+				Id:       event.ID(),
 			}); err != nil {
 				return fmt.Errorf("cannot forward event info: %w", err)
 			}
@@ -212,6 +213,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 				Observer: env.SenderName,
 				Time:     time.Now(),
 				Sequence: uint64(sequence),
+				Id:       event.ID(),
 			}
 
 			sentHeaders := make(nethttp.Header)
@@ -242,6 +244,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 				Time:        time.Now(),
 				Sequence:    uint64(sequence),
 				StatusCode:  res.StatusCode,
+				Id:          event.ID(),
 			}
 			if responseMessage.ReadEncoding() == binding.EncodingUnknown {
 				body, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Add a field to EventInfo, Id. This is stuffed with the Event.Id so that we can actually correlate Sent / Response events
and inspect the statuscode to make sure it's what we expect.

Example usage here:
https://github.com/vaikas/eventing/commit/c9cd237e10f6e9f5f32b8a6f29a91c3247c61c99