### PR TITLE
Hunting the panic issue

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -47,6 +47,8 @@ func (mr *MagicEnvironment) executeWithoutWrappingT(ctx context.Context, origina
 
 func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) feature.T {
 	originalT.Helper()
+
+	// Create a cancel tied to this step
 	ctx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 
@@ -63,10 +65,6 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 			}
 		}()
 		internalT.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
-
-		// Create a cancel tied to this step
-		ctx, cancelFn := context.WithCancel(ctx)
-		internalT.Cleanup(cancelFn)
 
 		mr.milestones.StepStarted(f.Name, s, internalT)
 		internalT.Cleanup(func() {

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -64,11 +64,11 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 				internalT.Error("Panic happened:", r)
 			}
 		}()
-		internalT.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
 
 		mr.milestones.StepStarted(f.Name, s, internalT)
 		internalT.Cleanup(func() {
 			mr.milestones.StepFinished(f.Name, s, internalT)
+			wg.Done() // Make sure wg.Done() is always invoked, no matter what
 		})
 
 		// Perform step.

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -60,14 +60,14 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 				internalT.Error("panic happened", r)
 			}
 		}()
-		st.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
+		internalT.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what
 
 		// Create a cancel tied to this step
 		ctx, cancelFn := context.WithCancel(ctx)
-		st.Cleanup(cancelFn)
+		internalT.Cleanup(cancelFn)
 
 		mr.milestones.StepStarted(f.Name, s, internalT)
-		originalT.Cleanup(func() {
+		internalT.Cleanup(func() {
 			mr.milestones.StepFinished(f.Name, s, internalT)
 		})
 

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -30,12 +30,14 @@ func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.St
 }
 
 // executeWithSkippingT executes the step in a sub test wrapping t in order to never fail the subtest
+// This blocks until the test completes.
 func (mr *MagicEnvironment) executeWithSkippingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
 	originalT.Helper()
 	return mr.executeStep(ctx, originalT, f, s, createSkippingT)
 }
 
-// executeWithoutWrappingT executes the step in a sub test without wrapping t
+// executeWithoutWrappingT executes the step in a sub test without wrapping t.
+// This blocks until the test completes.
 func (mr *MagicEnvironment) executeWithoutWrappingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
 	originalT.Helper()
 	return mr.executeStep(ctx, originalT, f, s, func(t *testing.T) feature.T {
@@ -52,12 +54,12 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.
 	wg.Add(1)
 
 	var internalT feature.T
-	originalT.Run(s.T.String()+"/"+s.TestName(), func(st *testing.T) {
+	originalT.Run(f.Name+"/"+s.T.String()+"/"+s.TestName(), func(st *testing.T) {
 		st.Helper()
 		internalT = tDecorator(st)
 		defer func() {
 			if r := recover(); r != nil {
-				internalT.Error("panic happened", r)
+				internalT.Error("Panic happened:", r)
 			}
 		}()
 		internalT.Cleanup(wg.Done) // Make sure wg.Done() is always invoked, no matter what

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -212,9 +212,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 	originalT.Helper() // Helper marks the calling function as a test helper function.
 
 	mr.milestones.TestStarted(f.Name, originalT)
-	originalT.Cleanup(func() {
-		mr.milestones.TestFinished(f.Name, originalT)
-	})
+	defer mr.milestones.TestFinished(f.Name, originalT)
 
 	if f.State == nil {
 		f.State = &state.KVStore{}
@@ -295,9 +293,7 @@ func (mr *MagicEnvironment) TestSet(ctx context.Context, t *testing.T, fs *featu
 	t.Helper() // Helper marks the calling function as a test helper function
 
 	mr.milestones.TestSetStarted(fs.Name, t)
-	t.Cleanup(func() {
-		mr.milestones.TestSetFinished(fs.Name, t)
-	})
+	defer mr.milestones.TestSetFinished(fs.Name, t)
 
 	for _, f := range fs.Features {
 		// Make sure the name is appended


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This PR includes assorted fixes and small mistakes I've found in the attempt to fix the panic experienced here: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/5149/pull-knative-eventing-reconciler-tests/1375038550466105344

* The cleanup was registered on the wrong t in `execution.go`
* Some comments on the semantics of methods in execution.go
* Remove unnecessary nested test
* Fix subtest name
* Removed unnecessary internal context