### PR TITLE
do not use t outside of test

### DIFF
--- a/pkg/eventshub/assert/step.go
+++ b/pkg/eventshub/assert/step.go
@@ -38,7 +38,7 @@ func (m MatchAssertionBuilder) MatchEvent(matchers ...cetest.EventMatcher) Match
 // OnStore(store).Match(matchers).AtLeast(min) is equivalent to StoreFromContext(ctx, store).AssertAtLeast(min, matchers)
 func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(min, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(t, min, m.matchers...)
 	}
 }
 
@@ -46,7 +46,7 @@ func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 // OnStore(store).Match(matchers).InRange(min, max) is equivalent to StoreFromContext(ctx, store).AssertInRange(min, max, matchers)
 func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(min, max, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(t, min, max, m.matchers...)
 	}
 }
 
@@ -54,7 +54,7 @@ func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 // OnStore(store).Match(matchers).Exact(n) is equivalent to StoreFromContext(ctx, store).AssertExact(n, matchers)
 func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(n, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(t, n, m.matchers...)
 	}
 }
 
@@ -62,6 +62,6 @@ func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 // OnStore(store).Match(matchers).Not() is equivalent to StoreFromContext(ctx, store).AssertNot(matchers)
 func (m MatchAssertionBuilder) Not() feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(t, m.matchers...)
 	}
 }

--- a/pkg/eventshub/event_info_store.go
+++ b/pkg/eventshub/event_info_store.go
@@ -46,8 +46,6 @@ type EventInfoMatcher func(eventshub.EventInfo) error
 // Stateful store of events published by eventshub pod it is pointed at.
 // Implements k8s.EventHandler
 type Store struct {
-	t feature.T
-
 	podName      string
 	podNamespace string
 
@@ -67,7 +65,6 @@ func StoreFromContext(ctx context.Context, name string) *Store {
 
 func registerEventsHubStore(eventListener *k8s.EventListener, t feature.T, podName string, podNamespace string) {
 	store := &Store{
-		t:            t,
 		podName:      podName,
 		podNamespace: podNamespace,
 	}
@@ -99,7 +96,7 @@ func (ei *Store) Handle(event *corev1.Event) {
 	eventInfo := eventshub.EventInfo{}
 	err := json.Unmarshal([]byte(event.Message), &eventInfo)
 	if err != nil {
-		ei.t.Errorf("Received EventInfo that cannot be unmarshalled! %+v", err)
+		fmt.Printf("[ERROR] Received EventInfo that cannot be unmarshalled! %+v\n", err)
 		return
 	}
 
@@ -155,48 +152,48 @@ func (ei *Store) Find(matchers ...EventInfoMatcher) ([]eventshub.EventInfo, even
 
 // AssertAtLeast assert that there are at least min number of match for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
-func (ei *Store) AssertAtLeast(min int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
+func (ei *Store) AssertAtLeast(t feature.T, min int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
 	events, err := ei.waitAtLeastNMatch(allOf(matchers...), min)
 	if err != nil {
-		ei.t.Fatalf("Timeout waiting for at least %d matches.\nError: %+v", min, errors.WithStack(err))
+		t.Fatalf("Timeout waiting for at least %d matches.\nError: %+v", min, errors.WithStack(err))
 	}
-	ei.t.Logf("Assert passed")
+	t.Logf("Assert passed")
 	return events
 }
 
 // AssertInRange asserts that there are at least min number of matches and at most max number of matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
-func (ei *Store) AssertInRange(min int, max int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
-	events := ei.AssertAtLeast(min, matchers...)
+func (ei *Store) AssertInRange(t feature.T, min int, max int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
+	events := ei.AssertAtLeast(t, min, matchers...)
 	if max > 0 && len(events) > max {
-		ei.t.Fatalf("Assert in range failed: %+v", errors.WithStack(fmt.Errorf("expected <= %d events, saw %d", max, len(events))))
+		t.Fatalf("Assert in range failed: %+v", errors.WithStack(fmt.Errorf("expected <= %d events, saw %d", max, len(events))))
 	}
-	ei.t.Logf("Assert passed")
+	t.Logf("Assert passed")
 	return events
 }
 
 // AssertNot asserts that there aren't any matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
-func (ei *Store) AssertNot(matchers ...EventInfoMatcher) []eventshub.EventInfo {
+func (ei *Store) AssertNot(t feature.T, matchers ...EventInfoMatcher) []eventshub.EventInfo {
 	res, recentEvents, _, err := ei.Find(matchers...)
 	if err != nil {
-		ei.t.Fatalf("Unexpected error during find on eventshub '%s': %+v", ei.podName, errors.WithStack(err))
+		t.Fatalf("Unexpected error during find on eventshub '%s': %+v", ei.podName, errors.WithStack(err))
 	}
 
 	if len(res) != 0 {
-		ei.t.Fatalf("Assert not failed: %+v", errors.WithStack(
+		t.Fatalf("Assert not failed: %+v", errors.WithStack(
 			fmt.Errorf("Unexpected matches on eventshub '%s', found: %v. %s", ei.podName, res, &recentEvents)),
 		)
 	}
-	ei.t.Logf("Assert passed")
+	t.Logf("Assert passed")
 	return res
 }
 
 // AssertExact assert that there are exactly n matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
-func (ei *Store) AssertExact(n int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
-	events := ei.AssertInRange(n, n, matchers...)
-	ei.t.Logf("Assert passed")
+func (ei *Store) AssertExact(t feature.T, n int, matchers ...EventInfoMatcher) []eventshub.EventInfo {
+	events := ei.AssertInRange(t, n, n, matchers...)
+	t.Logf("Assert passed")
 	return events
 }
 

--- a/test/example/recorder_feature.go
+++ b/test/example/recorder_feature.go
@@ -44,7 +44,7 @@ func RecorderFeature() *feature.Feature {
 
 	f.Setup("install recorder", func(ctx context.Context, t feature.T) {
 		to := feature.MakeRandomK8sName("recorder")
-		eventshub.Install(to, eventshub.StartReceiver)
+		eventshub.Install(to, eventshub.StartReceiver)(ctx, t)
 		state.SetOrFail(ctx, t, "to", to)
 	})
 
@@ -53,12 +53,12 @@ func RecorderFeature() *feature.Feature {
 		var event cloudevents.Event
 		state.GetOrFail(ctx, t, "event", &event)
 		from := feature.MakeRandomK8sName("sender")
-		eventshub.Install(from, eventshub.StartSender(to), eventshub.InputEvent(event))
+		eventshub.Install(from, eventshub.StartSender(to), eventshub.InputEvent(event))(ctx, t)
 	})
 
 	f.Requirement("recorder is addressable", func(ctx context.Context, t feature.T) {
 		to := state.GetStringOrFail(ctx, t, "to")
-		k8s.IsAddressable(svc, to, time.Second, 30*time.Second)
+		k8s.IsAddressable(svc, to, time.Second, 30*time.Second)(ctx, t)
 	})
 
 	f.Alpha("direct sending between a producer and a recorder").
@@ -67,7 +67,7 @@ func RecorderFeature() *feature.Feature {
 				to := state.GetStringOrFail(ctx, t, "to")
 				var event cloudevents.Event
 				state.GetOrFail(ctx, t, "event", &event)
-				OnStore(to).MatchEvent(HasId(event.ID())).Exact(1)
+				OnStore(to).MatchEvent(HasId(event.ID())).Exact(1)(ctx, t)
 			})
 
 	return f


### PR DESCRIPTION
I found that the tests panic with 

```

goroutine 49 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x109
panic(0x2479560, 0xc0002cfa70)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
testing.(*common).Fail(0xc000fa2780)
	/usr/local/go/src/testing/testing.go:698 +0x125
testing.(*common).Errorf(0xc000fa2780, 0x2799367, 0x33, 0xc0002cf950, 0x1, 0x1)
	/usr/local/go/src/testing/testing.go:804 +0x93
knative.dev/reconciler-test/pkg/eventshub.(*Store).Handle(0xc0003140c0, 0xc000f92000)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/pkg/eventshub/event_info_store.go:102 +0x3a3
knative.dev/reconciler-test/pkg/k8s.(*EventListener).handle(0xc000428e80, 0xc000f92000)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/pkg/k8s/events.go:103 +0xf7
knative.dev/reconciler-test/pkg/k8s.newEventListener.func1(0x272a1e0, 0xc000f92000)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/pkg/k8s/events.go:84 +0x45
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/client-go/tools/cache/controller.go:227
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/client-go/tools/cache/shared_informer.go:777 +0xc2
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000974760)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000bb3f60, 0x29e2980, 0xc000b92000, 0x24bde01, 0xc00010e120)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000974760, 0x3b9aca00, 0x0, 0x1, 0xc00010e120)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc0000e8300)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/client-go/tools/cache/shared_informer.go:771 +0x95
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc0005a40d0, 0xc000b80000)
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x51
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/Users/snichols/go/src/github.com/knative-sandbox/reconciler-test/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x65
FAIL	knative.dev/reconciler-test/test/example	59.198s
?   	knative.dev/reconciler-test/test/example/cmd/echo	[no test files]
```


The root cause is because eventshub stores `feature.T` from the `Setup(install)` call and then if we attempt to use `t` after the setup phase finishes, we get a panic. 