### PR TITLE
Implement step planning event

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -225,6 +225,8 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 	skipRequirements := false
 	skipReason := ""
 
+	mr.milestones.StepsPlanned(f.Name, steps, originalT)
+
 	for _, s := range steps[feature.Setup] {
 		s := s
 

--- a/pkg/milestone/emitter.go
+++ b/pkg/milestone/emitter.go
@@ -49,6 +49,7 @@ type Emitter interface {
 	NamespaceDeleted(namespace string)
 	TestStarted(feature string, t feature.T)
 	TestFinished(feature string, t feature.T)
+	StepsPlanned(feature string, steps map[feature.Timing][]feature.Step, t feature.T)
 	StepStarted(feature string, step *feature.Step, t feature.T)
 	StepFinished(feature string, step *feature.Step, t feature.T)
 	TestSetStarted(featureSet string, t feature.T)
@@ -134,6 +135,22 @@ func (n *NilSafeClient) TestFinished(feature string, t feature.T) {
 		return
 	}
 	n.Event(context.Background(), n.Factory.TestFinished(feature, t.Name(), t.Skipped(), t.Failed()))
+}
+
+func (n *NilSafeClient) StepsPlanned(feature string, steps map[feature.Timing][]feature.Step, t feature.T) {
+	if n == nil || n.Client == nil {
+		return
+	}
+
+	sm := make(map[string][]string)
+	for k, v := range steps {
+		sm[k.String()] = make([]string, len(v))
+		for i, step := range v {
+			sm[k.String()][i] = step.Name
+		}
+	}
+
+	n.Event(context.Background(), n.Factory.StepsPlanned(feature, sm, t.Name()))
 }
 
 func (n *NilSafeClient) StepStarted(feature string, step *feature.Step, t feature.T) {

--- a/pkg/milestone/factory.go
+++ b/pkg/milestone/factory.go
@@ -29,6 +29,7 @@ const (
 	NamespaceDeletedType = "dev.knative.rekt.namespace.deleted.v1"
 	TestStartedType      = "dev.knative.rekt.test.started.v1"
 	TestFinishedType     = "dev.knative.rekt.test.finished.v1"
+	StepsPlannedType     = "dev.knative.rekt.steps.planned.v1"
 	StepStartedType      = "dev.knative.rekt.step.started.v1"
 	StepFinishedType     = "dev.knative.rekt.step.finished.v1"
 	TestSetStartedType   = "dev.knative.rekt.testset.started.v1"
@@ -126,6 +127,29 @@ func (ef *Factory) TestFinished(feature, testName string, skipped, failed bool) 
 		"skipped":  skipped,
 		"failed":   failed,
 		"passed":   !failed && !skipped,
+	})
+
+	return event
+}
+
+func (ef *Factory) StepsPlanned(feature string, steps map[string][]string, testName string) cloudevents.Event {
+	event := ef.baseEvent(StepsPlannedType)
+
+	lparts := strings.Split(testName, "/")
+	if len(lparts) > 0 {
+		event.SetExtension("testparent", lparts[0])
+	}
+
+	event.SetExtension("feature", feature)
+	event.SetExtension("testname", testName)
+
+	// TODO: we can log a whole lot of stuff here but we need a more formal structure to track
+	// where we are in the test to be able to assemble it.
+
+	_ = event.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
+		"feature":  feature,
+		"steps":    steps,
+		"testName": testName,
 	})
 
 	return event


### PR DESCRIPTION
This change enables consumers of the event milestone stream plan ahead for what results are going to come for a single feature run. This could be used to implement something like a progress bar, etc.