### PR TITLE
Fail on feature.Require errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,16 @@ ordering is required it is recommended to break that into an independent feature
 that is tested on an environment in order required.
 
 Features have 4 phases (timing) on which steps can be composed: Setup,
-Requirement, Assert, and Teardown. The step functions are run in that order.
+Requirement, Assert, and Teardown. The step functions run in that order.
 
-- Setup is used to install required components or configuration in the
+- **Setup** is used to install required components or configuration in the
   environment.
-- Requirement is used to validate the cluster, environment, or anything else.
-  Think of this as a preflight validation for the assertions.
-- Assert should assume the namespace is ready to perform or validate the test.
-- Teardown should be used to do final feature cleanup, if needed. There is also
-  automatic cleanup of resources and namespace for the environment.
+- **Requirement** is used to validate the cluster, environment, or anything
+  else. Think of this as a preflight validation for the assertions.
+- **Assert** should assume the namespace is ready to perform or validate the
+  test.
+- **Teardown** should be used to do final feature cleanup, if needed. There is
+  also automatic cleanup of resources and namespace for the environment.
 
 Asserts have two additional properties that allow for filtering from within
 environment.Test, State and Level.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Requirement, Assert, and Teardown. The step functions run in that order.
 - **Setup** is used to install required components or configuration in the
   environment.
 - **Requirement** is used to validate the cluster, environment, or anything
-  else. Think of this as a preflight validation for the assertions.
+  else. Think of this as a preflight validation for the assertions. This can be
+  used as a fast-fail for a feature test before running assert phase steps.
 - **Assert** should assume the namespace is ready to perform or validate the
   test.
 - **Teardown** should be used to do final feature cleanup, if needed. There is

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -248,13 +248,11 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 			break
 		}
 
-		// Requirement never fails the parent test
-		internalT := mr.executeWithSkippingT(ctx, originalT, f, &s)
+		internalT := mr.executeWithoutWrappingT(ctx, originalT, f, &s)
 
 		if internalT.Failed() {
 			skipAssertions = true
 			skipRequirements = true // No need to test other requirements
-			skipReason = fmt.Sprintf("requirement %q failed", s.Name)
 		}
 	}
 
@@ -286,6 +284,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 	}
 }
 
+// TODO: this logic is strange and hard to follow.
 func (mr *MagicEnvironment) shouldFail(s *feature.Step) bool {
 	return !(mr.s&s.S == 0 || mr.l&s.L == 0)
 }

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -33,6 +33,53 @@ import (
 
 // These are example tests that fail intentionally to demonstrate feature timings working.
 
+func TestRequirementFail(t *testing.T) {
+	// Signal to the go test framework that this test can be run in parallel
+	// with other tests.
+	t.Parallel()
+
+	ctx, env := global.Environment(environment.Managed(t))
+
+	// We assert at the end on this string
+	stringBuilder := &strings.Builder{}
+
+	// Build the feature
+	feat := feature.NewFeature()
+
+	counter := int32(0)
+
+	feat.Setup("setup1", appender(stringBuilder, "setup1"))
+	feat.Setup("setup2", appender(stringBuilder, "setup2"))
+	feat.Setup("setup3", appender(stringBuilder, "setup3"))
+	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
+	feat.Requirement("requirement2", func(ctx context.Context, t feature.T) {
+		t.Fatalf("We can't fulfill this requirement")
+		appender(stringBuilder, "requirement2")
+	})
+	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
+	feat.Stable("A cool feature").
+		Must("aaa", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("bbb", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		}).
+		Must("ccc", func(ctx context.Context, t feature.T) {
+			time.Sleep(1 * time.Second)
+			atomic.AddInt32(&counter, 1)
+		})
+	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
+	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
+	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
+
+	env.Test(ctx, t, feat)
+
+	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
+	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
+}
+
 // This should fail because a setup phase failed
 func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 	// Signal to the go test framework that this test can be run in parallel

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -77,53 +77,6 @@ func TestTimingConstraints(t *testing.T) {
 	require.Equal(t, "setup1setup2setup3requirement1requirement2requirement3teardown1teardown2teardown3", stringBuilder.String())
 }
 
-func TestRequirementSkip(t *testing.T) {
-	// Signal to the go test framework that this test can be run in parallel
-	// with other tests.
-	t.Parallel()
-
-	ctx, env := global.Environment(environment.Managed(t))
-
-	// We assert at the end on this string
-	stringBuilder := &strings.Builder{}
-
-	// Build the feature
-	feat := feature.NewFeature()
-
-	counter := int32(0)
-
-	feat.Setup("setup1", appender(stringBuilder, "setup1"))
-	feat.Setup("setup2", appender(stringBuilder, "setup2"))
-	feat.Setup("setup3", appender(stringBuilder, "setup3"))
-	feat.Requirement("requirement1", appender(stringBuilder, "requirement1"))
-	feat.Requirement("requirement2", func(ctx context.Context, t feature.T) {
-		t.Fatalf("We can't fulfill this requirement")
-		appender(stringBuilder, "requirement2")
-	})
-	feat.Requirement("requirement3", appender(stringBuilder, "requirement3"))
-	feat.Stable("A cool feature").
-		Must("aaa", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		}).
-		Must("bbb", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		}).
-		Must("ccc", func(ctx context.Context, t feature.T) {
-			time.Sleep(1 * time.Second)
-			atomic.AddInt32(&counter, 1)
-		})
-	feat.Teardown("teardown1", appender(stringBuilder, "teardown1"))
-	feat.Teardown("teardown2", appender(stringBuilder, "teardown2"))
-	feat.Teardown("teardown3", appender(stringBuilder, "teardown3"))
-
-	env.Test(ctx, t, feat)
-
-	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
-	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
-}
-
 func TestContextLifecycle(t *testing.T) {
 	// Signal to the go test framework that this test can be run in parallel
 	// with other tests.


### PR DESCRIPTION
fixes #181 

- **Requirement** is used to validate the cluster, environment, or anything
  else. Think of this as a preflight validation for the assertions. This can be
  used as a fast-fail for a feature test before running assert phase steps.