### PR TITLE
#180 add flag to allow filtering of features while running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ disabled using the following flags:
 | --requirement.shouldnot | Boolean | Enable/Disable running Should Not level features. |
 | --requirement.may       | Boolean | Enable/Disable running May level features.        |
 | --requirement.all       | Boolean | Enable/Disable running All level features.        |
+| --feature               | RegExp  | Specify features to run.                          |
 
 They can be used in combination, to run only Beta state features:
 
@@ -378,4 +379,10 @@ And normal go filters work on the go test entry point names.
 
 ```shell
 go test -v -count=1 -tags=e2e ./test/... --feature.any=false --feature.beta -run TestKoPublish
+```
+
+Run all instances of Noop feature, including instances in a Feature Set
+
+```shell
+go test -v -count=1 -tags=e2e ./test/... --feature=Noop
 ```

--- a/pkg/environment/flags.go
+++ b/pkg/environment/flags.go
@@ -28,6 +28,7 @@ import (
 var (
 	s = new(feature.States)
 	l = new(feature.Levels)
+	f = new(string)
 )
 
 // InitFlags registers the requirement and state filter flags supported by the
@@ -50,6 +51,9 @@ func InitFlags(fs *flag.FlagSet) {
 		fs.Var(levelValue{level, l}, flagName, usage)
 	}
 	fs.Var(levelValue{feature.All, l}, "requirement.all", "toggles all requirement assertions")
+
+	// Feature
+	fs.StringVar(f, "feature", "", "run only Features matching `regexp`")
 }
 
 type stateValue struct {

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -34,13 +35,14 @@ import (
 )
 
 func NewGlobalEnvironment(ctx context.Context) GlobalEnvironment {
-	fmt.Printf("level %s, state %s\n\n", l, s)
+	fmt.Printf("level %s, state %s, feature %s\n\n", l, s, *f)
 
 	return &MagicGlobalEnvironment{
 		c:                ctx,
 		instanceID:       uuid.New().String(),
 		RequirementLevel: *l,
 		FeatureState:     *s,
+		FeatureMatch:     regexp.MustCompile(*f),
 	}
 }
 
@@ -52,12 +54,14 @@ type MagicGlobalEnvironment struct {
 
 	RequirementLevel feature.Levels
 	FeatureState     feature.States
+	FeatureMatch     *regexp.Regexp
 }
 
 type MagicEnvironment struct {
-	c context.Context
-	l feature.Levels
-	s feature.States
+	c            context.Context
+	l            feature.Levels
+	s            feature.States
+	featureMatch *regexp.Regexp
 
 	images           map[string]string
 	namespace        string
@@ -113,9 +117,11 @@ func (mr *MagicGlobalEnvironment) Environment(opts ...EnvOpts) (context.Context,
 	namespace := feature.MakeK8sNamePrefix(feature.AppendRandomString("test"))
 
 	env := &MagicEnvironment{
-		c:         mr.c,
-		l:         mr.RequirementLevel,
-		s:         mr.FeatureState,
+		c:            mr.c,
+		l:            mr.RequirementLevel,
+		s:            mr.FeatureState,
+		featureMatch: mr.FeatureMatch,
+
 		images:    images,
 		namespace: namespace,
 	}
@@ -210,6 +216,11 @@ func (mr *MagicEnvironment) Prerequisite(ctx context.Context, t *testing.T, f *f
 // apply it to the Context.
 func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *feature.Feature) {
 	originalT.Helper() // Helper marks the calling function as a test helper function.
+
+	if !mr.featureMatch.MatchString(f.Name) {
+		originalT.Logf("Skipping feature '%s' assertions because --feature=%s  doesn't match", f.Name, mr.featureMatch.String())
+		return
+	}
 
 	mr.milestones.TestStarted(f.Name, originalT)
 	defer mr.milestones.TestFinished(f.Name, originalT)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -38,7 +38,7 @@ import (
 var global environment.GlobalEnvironment
 
 func init() {
-	// environment.InitFlags registers state and level filter flags.
+	// environment.InitFlags registers state, level and feature filter flags.
 	environment.InitFlags(flag.CommandLine)
 }
 


### PR DESCRIPTION
# Changes
- :gift: Add --feature flag for filtering
    - if not set, all features are run
    - if set, the features are matched using the given regexp and the
      feature is skipped if it doesn't match. Rather than use the built-in
      skip, which skips the remainder of the test, none of the feature
      phases are executed.
    - eg. `go test -v -tags=e2e ./test/example/ --feature ^Noop$`

fixes #180 