### PR TITLE
Use go 1.16 embed for templates

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -11,7 +11,7 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.16.x ]
         platform: [ ubuntu-latest ]
         ko-version: [ 0.8.1 ]
         kind-version: [ 0.8.1 ]

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -43,10 +43,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-    - name: Set up Go 1.15.x
+    - name: Set up Go 1.16.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
     - name: Install Dependencies
       run: |
         go get github.com/google/go-licenses

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/reconciler-test
 
-go 1.14
+go 1.16
 
 require (
 	github.com/cloudevents/conformance v0.2.0

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eventshub_test
 
 import (
+	"embed"
 	"encoding/json"
 	"os"
 	"testing"
@@ -24,6 +25,9 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var templates embed.FS
 
 func Example() {
 	images := map[string]string{
@@ -39,7 +43,7 @@ func Example() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(templates, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -18,6 +18,7 @@ package eventshub
 
 import (
 	"context"
+	"embed"
 	"strings"
 
 	"knative.dev/reconciler-test/pkg/environment"
@@ -27,8 +28,11 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
+//go:embed *.yaml
+var templates embed.FS
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+	environment.RegisterPackage(manifest.ImagesFromFS(templates)...)
 }
 
 // Install starts a new eventshub with the provided name
@@ -54,7 +58,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		envs[ConfigTracingEnv] = knative.TracingConfigFromContext(ctx)
 
 		// Deploy
-		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{
+		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
 			"name": name,
 			"envs": envs,
 		}); err != nil {

--- a/resources/svc/service.go
+++ b/resources/svc/service.go
@@ -18,6 +18,7 @@ package svc
 
 import (
 	"context"
+	"embed"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
@@ -28,6 +29,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var templates embed.FS
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
@@ -43,7 +47,7 @@ func Install(name, selectorKey, selectorValue string) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, templates, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/resources/svc/service_test.go
+++ b/resources/svc/service_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package svc_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var templates embed.FS
 
 func Example() {
 	images := map[string]string{}
@@ -31,7 +35,7 @@ func Example() {
 		"selectorValue": "baf",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(templates, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/example/config/echo/echo.go
+++ b/test/example/config/echo/echo.go
@@ -18,14 +18,18 @@ package echo
 
 import (
 	"context"
+	"embed"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
+//go:embed *.yaml
+var templates embed.FS
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+	environment.RegisterPackage(manifest.ImagesFromFS(templates)...)
 }
 
 // Output is the base output we can expect from a echo job.
@@ -36,7 +40,7 @@ type Output struct {
 
 func Install(name, message string) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{
+		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
 			"name":    name,
 			"message": message,
 		}); err != nil {

--- a/test/example/config/echo/echo_test.go
+++ b/test/example/config/echo/echo_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package echo_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var templates embed.FS
 
 func Example() {
 	images := map[string]string{
@@ -32,7 +36,7 @@ func Example() {
 		"message":   "Hello, World!",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(templates, images, cfg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Changes

- :gift:  YAML helpers now take an [fs.FS](https://golang.org/pkg/io/fs/#FS), allowing us to use the new [embed package](https://golang.org/pkg/embed/) for bundling yaml into test binaries


/kind enhancement

Fixes #193