### PR TITLE
Add Kafka projects to downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -34,6 +34,10 @@ jobs:
             org: knative-sandbox
           - repo: eventing-natss
             org: knative-sandbox
+          - repo: eventing-kafka
+            org: knative-sandbox
+          - repo: eventing-kafka-broker
+            org: knative-sandbox
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
`eventing-kafka` and `eventing-kafka-broker` are using rekt too!
