### PR TITLE
Add a way to manually add event assertions

### DIFF
--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -264,6 +264,11 @@ func (p *EventProber) ExpectYAMLEvents(path string) error {
 	return nil
 }
 
+// ExpectEvents registers event IDs into the prober.
+func (p *EventProber) ExpectEvents(ids []string) {
+	p.ids = append(p.ids, ids...)
+}
+
 // SenderEventsFromURI configures a sender to send a url/yaml based events.
 func (p *EventProber) SenderEventsFromURI(uri string) {
 	p.senderOptions = append(p.senderOptions, InputYAML(uri))


### PR DESCRIPTION
In trying to port [these e2e tests](https://github.com/knative/eventing/blob/main/test/e2e/channel_single_event_test.go) to rekt, I found myself needing to manually construct events and have eventshub deliver them via the [InputEventWithEncoding](https://github.com/knative-sandbox/reconciler-test/blob/main/pkg/eventshub/options.go#L154) option. The problem I ran into then was that there is no way to register these events into the prober as expectations. As far as I can tell the only helper right now is `ExpectYAMLEvents`, which takes a file path.