### PR TITLE
Add a flag to skip publishing images

### DIFF
--- a/pkg/environment/flags.go
+++ b/pkg/environment/flags.go
@@ -29,6 +29,7 @@ var (
 	s = new(feature.States)
 	l = new(feature.Levels)
 	f = new(string)
+	publish = new(bool)
 )
 
 // InitFlags registers the requirement and state filter flags supported by the
@@ -54,6 +55,7 @@ func InitFlags(fs *flag.FlagSet) {
 
 	// Feature
 	fs.StringVar(f, "feature", "", "run only Features matching `regexp`")
+	fs.BoolVar(publish, "publish", true, "publish test images with ko")
 }
 
 type stateValue struct {

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -109,9 +109,15 @@ func Managed(t feature.T) EnvOpts {
 }
 
 func (mr *MagicGlobalEnvironment) Environment(opts ...EnvOpts) (context.Context, Environment) {
-	images, err := ProduceImages()
-	if err != nil {
-		panic(err)
+	var (
+		images map[string]string
+		err    error
+	)
+	if *publish {
+		images, err = ProduceImages()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	namespace := feature.MakeK8sNamePrefix(feature.AppendRandomString("test"))


### PR DESCRIPTION
I decided to be verbose with actually spelling out the word `publish` 😸 . This is useful when re-running tests, as you've probably already published the images.