### PR TITLE
Skip emitting events if they are eventshub events

### DIFF
--- a/pkg/eventshub/recorder_vent/recorder.go
+++ b/pkg/eventshub/recorder_vent/recorder.go
@@ -42,6 +42,14 @@ type recorder struct {
 }
 
 func (r *recorder) Vent(observed eventshub.EventInfo) error {
+	if observed.Event != nil {
+		var event corev1.Event
+		err := json.Unmarshal(observed.Event.DataEncoded, &event)
+		if err == nil && event.Reason == eventshub.CloudEventObservedReason {
+			// prevent event loops from happening with APIServerSources
+			return nil
+		}
+	}
 	b, err := json.Marshal(observed)
 	if err != nil {
 		return err


### PR DESCRIPTION
With APIServerSources it's possible to get our own event back as a cloudevent, which causes a loop.