### PR TITLE
Fix eventshub race

### DIFF
--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"time"
 
@@ -141,7 +142,7 @@ func (p *EventProber) SenderDone(prefix string) feature.StepFn {
 		interval, timeout := environment.PollTimingsFromContext(ctx)
 		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 			events := p.SentBy(ctx, prefix)
-			fmt.Println(prefix, "has sent", len(events))
+			log.Println(p.shortNameToName[prefix], "has sent", len(events))
 			if len(events) == len(p.ids) {
 				return true, nil
 			}
@@ -159,13 +160,13 @@ func (p *EventProber) ReceiverDone(from, to string) feature.StepFn {
 		interval, timeout := environment.PollTimingsFromContext(ctx)
 		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 			sent := p.SentBy(ctx, from)
-			fmt.Println(from, "has sent", len(sent))
+			log.Println(p.shortNameToName[from], "has sent", len(sent))
 
 			received := p.ReceivedBy(ctx, to)
-			fmt.Println(to, "has received", len(received))
+			log.Println(p.shortNameToName[to], "has received", len(received))
 
 			rejected := p.RejectedBy(ctx, to)
-			fmt.Println(to, "has rejected", len(rejected))
+			log.Println(p.shortNameToName[to], "has rejected", len(rejected))
 
 			if len(sent) == len(received)+len(rejected) {
 				return true, nil

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -57,6 +57,14 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		envs[ConfigLoggingEnv] = knative.LoggingConfigFromContext(ctx)
 		envs[ConfigTracingEnv] = knative.TracingConfigFromContext(ctx)
 
+		// Register the event info store to assert later the events published by the eventshub
+		registerEventsHubStore(
+			k8s.EventListenerFromContext(ctx),
+			t,
+			name,
+			environment.FromContext(ctx).Namespace(),
+		)
+
 		// Deploy
 		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
 			"name": name,
@@ -71,13 +79,5 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		if strings.Contains(envs["EVENT_GENERATORS"], "receiver") {
 			k8s.WaitForServiceEndpointsOrFail(ctx, t, name, 1)
 		}
-
-		// Register the event info store to assert later the events published by the eventshub
-		registerEventsHubStore(
-			k8s.EventListenerFromContext(ctx),
-			t,
-			name,
-			environment.FromContext(ctx).Namespace(),
-		)
 	}
 }


### PR DESCRIPTION
# Changes

- :bug: Fix a race where we can miss events that are emitted before our event listener is registered
- :broom: Add more helpful logs with timestamps and resolved names

/kind bug