### PR TITLE
register eventshub store first to prevent loss of events

### DIFF
--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -65,13 +65,6 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			t.Fatal(err)
 		}
 
-		k8s.WaitForPodRunningOrFail(ctx, t, name)
-
-		// If the eventhubs starts an event receiver, we need to wait for the service endpoint to be synced
-		if strings.Contains(envs["EVENT_GENERATORS"], "receiver") {
-			k8s.WaitForServiceEndpointsOrFail(ctx, t, name, 1)
-		}
-
 		// Register the event info store to assert later the events published by the eventshub
 		registerEventsHubStore(
 			k8s.EventListenerFromContext(ctx),
@@ -79,5 +72,13 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			name,
 			environment.FromContext(ctx).Namespace(),
 		)
+
+		k8s.WaitForPodRunningOrFail(ctx, t, name)
+
+		// If the eventhubs starts an event receiver, we need to wait for the service endpoint to be synced
+		if strings.Contains(envs["EVENT_GENERATORS"], "receiver") {
+			k8s.WaitForServiceEndpointsOrFail(ctx, t, name, 1)
+		}
+
 	}
 }


### PR DESCRIPTION
Fixs eventing flaky tests,like

* https://github.com/knative/eventing/runs/2888678781?check_suite_focus=true#step:12:5784
* https://github.com/knative/eventing/runs/2885623770?check_suite_focus=true#step:12:5596

These flaky tests are caused by the EventsHubStore not receiving the probe-sender's event which leads to the failure of the step of checking whether the probe-sender is completed.

After add logs to probe-sender pod and list all k8s event in the end. It is found that the probe-sender sent the event successfully. The problem is that the EventsHubStore did not receive this event.

The problem may be in the registered listener [section](https://github.com/knative-sandbox/reconciler-test/blob/main/pkg/eventshub/resources.go#L48),

Currently, the EventsHubStore is registered(`registerEventsHubStore()`) after the probe-sender pod is running/fail(`k8s.WaitForPodRunningOrFail()`). However, there may be a situation where the probe-sender pod has finished sending events and then the EventsHubStore starts to register EventListener. This will cause some events to be lost.

I ran kind-e2e tests more than 20 times on my [forked repo](https://github.com/xinydev/eventing/actions/workflows/kind-e2e.yaml), found that after applying this fix, these flaky tests did not occur


<!-- Thanks for sending a pull request! -->

# Changes

- :bug: change the order of `registerEventsHubStore` and `k8s.WaitForPodRunningOrFail()`, to prevent loss of probe-sender‘s event.


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
