### PR TITLE
More flexible eventshub main

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -14,7 +14,7 @@ jobs:
         go-version: [ 1.16.x ]
         platform: [ ubuntu-latest ]
         ko-version: [ 0.8.1 ]
-        kind-version: [ 0.8.1 ]
+        kind-version: [ 0.11.1 ]
 
     name: e2e tests
     runs-on: ${{ matrix.platform }}
@@ -58,7 +58,7 @@ jobs:
     - name: Create KinD Cluster
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       env:
-        NODE_IMAGE: 'kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765'
+        NODE_IMAGE: 'kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6'
       run: |
         set -x
 
@@ -107,7 +107,7 @@ jobs:
         kubectl get events --all-namespaces=true -oyaml
 
         echo "===================== Pod Logs ============================="
-        namespace=knative-eventing
+        namespace=knative-reconciler-test
         for pod in $(kubectl get pod -n $namespace | grep Running | awk '{print $1}'); do
           for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
             echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"

--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -24,7 +24,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: eventshub
-      image: ko://knative.dev/reconciler-test/cmd/eventshub
+      image: {{ .image }}
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "SYSTEM_NAMESPACE"

--- a/pkg/eventshub/event_info.go
+++ b/pkg/eventshub/event_info.go
@@ -64,6 +64,9 @@ type EventInfo struct {
 	// This is filled with the ID of the sent event (if any) and in the Response also
 	// jot it down so you can correlate which event (ID) as well as sequence to match sent/response 1:1.
 	SentId string `json:"id"`
+
+	// AdditionalInfo can be used by event generator implementations to add more event details
+	AdditionalInfo map[string]interface{} `json:"additionalInfo"`
 }
 
 // Pretty print the event. Meant for debugging.

--- a/pkg/eventshub/event_log.go
+++ b/pkg/eventshub/event_log.go
@@ -44,16 +44,10 @@ func (e *EventLogs) Vent(observed EventInfo) error {
 	return nil
 }
 
-type EventGeneratorType string
-
 const (
-	ReceiverEventGenerator EventGeneratorType = "receiver"
-	SenderEventGenerator   EventGeneratorType = "sender"
-)
+	ReceiverEventGenerator string = "receiver"
+	SenderEventGenerator   string = "sender"
 
-type EventLogType string
-
-const (
-	RecorderEventLog EventLogType = "recorder"
-	LoggerEventLog   EventLogType = "logger"
+	RecorderEventLog string = "recorder"
+	LoggerEventLog   string = "logger"
 )

--- a/pkg/eventshub/eventshub.go
+++ b/pkg/eventshub/eventshub.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub
+
+import (
+	"context"
+
+	"github.com/kelseyhightower/envconfig"
+	"golang.org/x/sync/errgroup"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+type envConfig struct {
+	EventGenerators []string `envconfig:"EVENT_GENERATORS" required:"true"`
+	EventLogs       []string `envconfig:"EVENT_LOGS" required:"true"`
+}
+
+// EventLogFactory creates a new EventLog instance.
+type EventLogFactory func(context.Context) (EventLog, error)
+
+// EventGeneratorStarter starts a new event generator. This function is executed in a separate goroutine, so it can block.
+type EventGeneratorStarter func(context.Context, *EventLogs) error
+
+// Start starts a new eventshub process, with the provided factories.
+// You can create your own eventshub providing event log factories and event generator factories.
+func Start(eventLogFactories map[string]EventLogFactory, eventGeneratorFactories map[string]EventGeneratorStarter) {
+	//nolint // nil ctx is fine here, look at the code of EnableInjectionOrDie
+	ctx, _ := injection.EnableInjectionOrDie(nil, nil)
+	ctx = ConfigureLogging(ctx, "eventshub")
+
+	if err := ConfigureTracing(logging.FromContext(ctx), ""); err != nil {
+		logging.FromContext(ctx).Fatal("Unable to setup trace publishing", err)
+	}
+
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		logging.FromContext(ctx).Fatal("Failed to process env var", err)
+	}
+	logging.FromContext(ctx).Infof("Events Hub environment configuration: %+v", env)
+
+	eventLogs := createEventLogs(ctx, eventLogFactories, env.EventLogs)
+	err := startEventGenerators(ctx, eventGeneratorFactories, env.EventGenerators, eventLogs)
+
+	if err != nil {
+		logging.FromContext(ctx).Fatal("Error during start: ", err)
+	}
+
+	logging.FromContext(ctx).Info("Closing the eventshub process")
+}
+
+func createEventLogs(ctx context.Context, factories map[string]EventLogFactory, logTypes []string) *EventLogs {
+	var eventLogs []EventLog
+	for _, logType := range logTypes {
+		factory, ok := factories[logType]
+		if !ok {
+			logging.FromContext(ctx).Fatal("Cannot recognize event log type: ", logType)
+		}
+
+		eventLog, err := factory(ctx)
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Error while instantiating the event log %s: %s", logType, err)
+		}
+
+		eventLogs = append(eventLogs, eventLog)
+	}
+	return NewEventLogs(eventLogs...)
+}
+
+func startEventGenerators(ctx context.Context, factories map[string]EventGeneratorStarter, genTypes []string, eventLogs *EventLogs) error {
+	errs, _ := errgroup.WithContext(ctx)
+	for _, genType := range genTypes {
+		factory, ok := factories[genType]
+		if !ok {
+			logging.FromContext(ctx).Fatal("Cannot recognize event generator type: ", genType)
+		}
+
+		errs.Go(func() error {
+			return factory(ctx, eventLogs)
+		})
+	}
+	return errs.Wait()
+}

--- a/pkg/eventshub/eventshub_image.go
+++ b/pkg/eventshub/eventshub_image.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub
+
+import (
+	"context"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+const defaultEventshubImage = "ko://knative.dev/reconciler-test/cmd/eventshub"
+
+type eventshubImageKey struct{}
+
+// ImageFromContext gets the eventshub image from context
+func ImageFromContext(ctx context.Context) string {
+	if e, ok := ctx.Value(eventshubImageKey{}).(string); ok {
+		return e
+	}
+	return defaultEventshubImage
+}
+
+// WithCustomImage allows you to specify a custom eventshub image to be used when invoking eventshub.Install
+func WithCustomImage(image string) environment.EnvOpts {
+	return func(ctx context.Context, env environment.Environment) (context.Context, error) {
+		return context.WithValue(ctx, eventshubImageKey{}, image), nil
+	}
+}

--- a/pkg/eventshub/eventshub_image.go
+++ b/pkg/eventshub/eventshub_image.go
@@ -22,7 +22,8 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 )
 
-const defaultEventshubImage = "ko://knative.dev/reconciler-test/cmd/eventshub"
+const thisPackage = "knative.dev/reconciler-test/cmd/eventshub"
+const defaultEventshubImage = "ko://" + thisPackage
 
 type eventshubImageKey struct{}
 

--- a/pkg/eventshub/eventshub_image.go
+++ b/pkg/eventshub/eventshub_image.go
@@ -22,8 +22,10 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 )
 
-const thisPackage = "knative.dev/reconciler-test/cmd/eventshub"
-const defaultEventshubImage = "ko://" + thisPackage
+const (
+	thisPackage           = "knative.dev/reconciler-test/cmd/eventshub"
+	defaultEventshubImage = "ko://" + thisPackage
+)
 
 type eventshubImageKey struct{}
 

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -36,7 +36,7 @@ func Example() {
 	cfg := map[string]interface{}{
 		"name":      "hubhub",
 		"namespace": "example",
-		"message":   "Hello, World!",
+		"image":     "ko://knative.dev/reconciler-test/cmd/eventshub",
 		"envs": map[string]string{
 			"foo": "bar",
 			"baz": "boof",

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -31,10 +31,8 @@ import (
 //go:embed *.yaml
 var templates embed.FS
 
-const imageName = "ko://knative.dev/reconciler-test/cmd/eventshub"
-
 func init() {
-	environment.RegisterPackage(imageName)
+	environment.RegisterPackage(defaultEventshubImage)
 }
 
 // Install starts a new eventshub with the provided name
@@ -48,11 +46,6 @@ func init() {
 //     k8s.WithEventListener,
 //   )
 func Install(name string, options ...EventsHubOption) feature.StepFn {
-	return InstallCustomImage(name, imageName, options...)
-}
-
-// InstallCustomImage is like Install, but allows you to specify a custom eventshub image.
-func InstallCustomImage(name string, image string, options ...EventsHubOption) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
 		// Compute the user provided envs
 		envs := make(map[string]string)
@@ -76,7 +69,7 @@ func InstallCustomImage(name string, image string, options ...EventsHubOption) f
 		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
 			"name":  name,
 			"envs":  envs,
-			"image": image,
+			"image": ImageFromContext(ctx),
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -31,8 +31,10 @@ import (
 //go:embed *.yaml
 var templates embed.FS
 
+const imageName = "ko://knative.dev/reconciler-test/cmd/eventshub"
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesFromFS(templates)...)
+	environment.RegisterPackage(imageName)
 }
 
 // Install starts a new eventshub with the provided name
@@ -46,6 +48,11 @@ func init() {
 //     k8s.WithEventListener,
 //   )
 func Install(name string, options ...EventsHubOption) feature.StepFn {
+	return InstallCustomImage(name, imageName, options...)
+}
+
+// InstallCustomImage is like Install, but allows you to specify a custom eventshub image.
+func InstallCustomImage(name string, image string, options ...EventsHubOption) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
 		// Compute the user provided envs
 		envs := make(map[string]string)
@@ -67,8 +74,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 
 		// Deploy
 		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
-			"name": name,
-			"envs": envs,
+			"name":  name,
+			"envs":  envs,
+			"image": image,
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -32,7 +32,7 @@ import (
 var templates embed.FS
 
 func init() {
-	environment.RegisterPackage(defaultEventshubImage)
+	environment.RegisterPackage(thisPackage)
 }
 
 // Install starts a new eventshub with the provided name

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -44,7 +44,7 @@ func TestRecorder(t *testing.T) {
 	// if customization is required.
 	ctx, env := global.Environment(
 		environment.Managed(t), // Will call env.Finish() when the test exits.
-		knative.WithKnativeNamespace("knative-eventing"),
+		knative.WithKnativeNamespace("knative-reconciler-test"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
@@ -67,7 +67,7 @@ func TestProber(t *testing.T) {
 	// if customization is required.
 	ctx, env := global.Environment(
 		environment.Managed(t), // Will call env.Finish() when the test exits.
-		knative.WithKnativeNamespace("knative-eventing"),
+		knative.WithKnativeNamespace("knative-reconciler-test"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,

--- a/test/example/examples_test.go
+++ b/test/example/examples_test.go
@@ -44,7 +44,7 @@ func TestRecorder(t *testing.T) {
 	// if customization is required.
 	ctx, env := global.Environment(
 		environment.Managed(t), // Will call env.Finish() when the test exits.
-		knative.WithKnativeNamespace("knative-reconciler-test"),
+		knative.WithKnativeNamespace("knative-eventing"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
@@ -67,7 +67,7 @@ func TestProber(t *testing.T) {
 	// if customization is required.
 	ctx, env := global.Environment(
 		environment.Managed(t), // Will call env.Finish() when the test exits.
-		knative.WithKnativeNamespace("knative-reconciler-test"),
+		knative.WithKnativeNamespace("knative-eventing"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

While working on https://github.com/knative-sandbox/eventing-kafka-broker/issues/1077, I've found out we have some test images that are basically acting as receivers for events, in a similar fashion to eventshub. This refactor of the main of eventshub will allow to create our own kafk-esque eventshub image, which can receive messages both from http and from kafka.

This code doesn't change any behaviour, just moves a bit the code to avoid duplicating code in eventing-kafka-broker and in general allows people to create their own custom eventshub images. 

# Changes

- :gift: Now most of the main code is moved to eventshub package, where downstream can use the `Start` method to assemble their own eventshub image
- :gift: Add a method to install an eventshub image specifying a custom image
- :gift: Add `EventInfo.AdditionalInfo` to store additional info in the `EventInfo` data structure (e.g. to store partition, topic and other kafka details)