### PR TITLE
Use namespaced RBAC for eventshub

### DIFF
--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: eventshub-{{ .name }}
 spec:
-  serviceAccountName: "{{ .name }}"
+  serviceAccountName: "{{ .namespace }}"
   restartPolicy: "Never"
   containers:
     - name: eventshub

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -51,44 +51,6 @@ func Example() {
 	manifest.OutputYAML(os.Stdout, files)
 	// Output:
 	// apiVersion: v1
-	// kind: ServiceAccount
-	// metadata:
-	//   name: hubhub
-	//   namespace: example
-	// ---
-	// apiVersion: rbac.authorization.k8s.io/v1
-	// kind: Role
-	// metadata:
-	//   name: hubhub
-	//   namespace: example
-	// rules:
-	//   - apiGroups: [ "" ]
-	//     resources:
-	//       - "pods"
-	//     verbs:
-	//       - "get"
-	//       - "list"
-	//   - apiGroups: [ "" ]
-	//     resources:
-	//       - "events"
-	//     verbs:
-	//       - "*"
-	// ---
-	// apiVersion: rbac.authorization.k8s.io/v1
-	// kind: RoleBinding
-	// metadata:
-	//   name: hubhub
-	//   namespace: example
-	// roleRef:
-	//   apiGroup: rbac.authorization.k8s.io
-	//   kind: Role
-	//   name: hubhub
-	// subjects:
-	//   - kind: ServiceAccount
-	//     name: hubhub
-	//     namespace: example
-	// ---
-	// apiVersion: v1
 	// kind: Service
 	// metadata:
 	//   name: hubhub
@@ -109,7 +71,7 @@ func Example() {
 	//   labels:
 	//     app: eventshub-hubhub
 	// spec:
-	//   serviceAccountName: "hubhub"
+	//   serviceAccountName: "example"
 	//   restartPolicy: "Never"
 	//   containers:
 	//     - name: eventshub

--- a/pkg/eventshub/rbac/100-sa.yaml
+++ b/pkg/eventshub/rbac/100-sa.yaml
@@ -15,5 +15,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .name }}
+  name: {{ .namespace }}
   namespace: {{ .namespace }}

--- a/pkg/eventshub/rbac/101-rbac.yaml
+++ b/pkg/eventshub/rbac/101-rbac.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .name }}
+  name: {{ .namespace }}
   namespace: {{ .namespace }}
 rules:
   - apiGroups: [ "" ]
@@ -35,13 +35,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .name }}
+  name: {{ .namespace }}
   namespace: {{ .namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .name }}
+  name: {{ .namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .name }}
+    name: {{ .namespace }}
     namespace: {{ .namespace }}

--- a/pkg/eventshub/rbac/rbac.go
+++ b/pkg/eventshub/rbac/rbac.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/eventshub/rbac/rbac_test.go
+++ b/pkg/eventshub/rbac/rbac_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub_test
+
+import (
+	"embed"
+	"os"
+
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var templates embed.FS
+
+func Example() {
+	files, err := manifest.ExecuteYAML(templates, nil,
+		map[string]interface{}{
+			"namespace": "example",
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: ServiceAccount
+	// metadata:
+	//   name: example
+	//   namespace: example
+	// ---
+	// apiVersion: rbac.authorization.k8s.io/v1
+	// kind: Role
+	// metadata:
+	//   name: example
+	//   namespace: example
+	// rules:
+	//   - apiGroups: [ "" ]
+	//     resources:
+	//       - "pods"
+	//     verbs:
+	//       - "get"
+	//       - "list"
+	//   - apiGroups: [ "" ]
+	//     resources:
+	//       - "events"
+	//     verbs:
+	//       - "*"
+	// ---
+	// apiVersion: rbac.authorization.k8s.io/v1
+	// kind: RoleBinding
+	// metadata:
+	//   name: example
+	//   namespace: example
+	// roleRef:
+	//   apiGroup: rbac.authorization.k8s.io
+	//   kind: Role
+	//   name: example
+	// subjects:
+	//   - kind: ServiceAccount
+	//     name: example
+	//     namespace: example
+}

--- a/pkg/eventshub/rbac/resources.go
+++ b/pkg/eventshub/rbac/resources.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub
+
+import (
+	"context"
+	"embed"
+
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var templates embed.FS
+
+// Install creates the necessary ServiceAccount, Role, RoleBinding for the eventshub.
+// The resources are named according to the current namespace defined in the environment.
+func Install() feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"knative.dev/reconciler-test/pkg/environment"
+	eventshubrbac "knative.dev/reconciler-test/pkg/eventshub/rbac"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
@@ -64,6 +65,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			name,
 			environment.FromContext(ctx).Namespace(),
 		)
+
+		// Install ServiceAccount, Role, RoleBinding
+		eventshubrbac.Install()(ctx, t)
 
 		// Deploy
 		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :broom: Update or clean up current behavior
-->

- Create ServiceAccount, Role, RoleBinding for eventshub with the same names as the namespace
- Extract the creation into a separate Install function so that we can later call this conditionally when running tests in pre-created namespace (this feature is TBD but I want to work on it soon) 

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #191

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
