### PR TITLE
Enhance eventshub receiver with drop events response headers.

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -120,6 +120,20 @@ func DropEventsResponseCode(code int) EventsHubOption {
 	)
 }
 
+// DropEventsResponseHeaders will cause the receiver to reply with the specific headers to the dropped events
+func DropEventsResponseHeaders(headers map[string]string) EventsHubOption {
+	headerEnvConfigString := ""
+	for k, v := range headers {
+		if headerEnvConfigString != "" {
+			headerEnvConfigString = headerEnvConfigString + ","
+		}
+		headerEnvConfigString = fmt.Sprintf("%s%s:%s", headerEnvConfigString, k, v) // Format as envconfig map[string]string
+	}
+	return compose(
+		envOptionalOpt("SKIP_RESPONSE_HEADERS", headerEnvConfigString),
+	)
+}
+
 // --- Sender options
 
 // InitialSenderDelay defines how much the sender has to wait (in millisecond), when started, before start sending events.


### PR DESCRIPTION
In order to test the changes in an eventing PR, I need to be able to reject events with a **429** response code (already supported) and the **"Retry-After"** header (not yet supported).  The framework doesn't currently support the ability to specify custom response headers for skipped/dropped events, so I am adding it here ; )
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁  Enhance eventshub receiver with ability to customize the HTTP Response headers for dropped/skipped events.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement





