### PR TITLE
isReady verifies resource generation and observed generation

### DIFF
--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -36,6 +36,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
@@ -145,6 +146,9 @@ func WaitForResourceCondition(ctx context.Context, namespace, name string, gvr s
 func isReady(name string) ConditionFunc {
 	lastMsg := ""
 	return func(obj duckv1.KResource) bool {
+		if obj.Generation != obj.GetStatus().ObservedGeneration {
+			return false
+		}
 		ready := readyCondition(obj)
 		if ready != nil {
 			if !ready.IsTrue() {


### PR DESCRIPTION
This patch adds a condition to the isReady function so that isReady
returns true only when the observed generation is equal to the
object generation since after a resource update isReady might
return true even though the latest spec could lead to a resource
not being ready (due to misconfiguration or missing dependencies).

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- isReady verifies resource generation and observed generation

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
isReady verifies resource generation and observed generation.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
