### PR TITLE
Wait for resource deletions in DeleteResources

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 
@@ -138,8 +140,6 @@ func (f *Feature) References() []corev1.ObjectReference {
 //
 // Expected to be used as a StepFn.
 func (f *Feature) DeleteResources(ctx context.Context, t T) {
-	// refFailedDeletion keeps the failed to delete resources.
-	var refFailedDeletion []corev1.ObjectReference
 	dc := dynamicclient.Get(ctx)
 	for _, ref := range f.References() {
 
@@ -151,8 +151,7 @@ func (f *Feature) DeleteResources(ctx context.Context, t T) {
 		resource := apis.KindToResource(gv.WithKind(ref.Kind))
 		t.Logf("Deleting %s/%s of GVR: %+v", ref.Namespace, ref.Name, resource)
 
-		// Delete immediately, grace period is 0.
-		deleteOptions := metav1.NewDeleteOptions(0)
+		deleteOptions := &metav1.DeleteOptions{}
 		// Set delete propagation policy to foreground
 		foregroundDeletePropagation := metav1.DeletePropagationForeground
 		deleteOptions.PropagationPolicy = &foregroundDeletePropagation
@@ -160,10 +159,46 @@ func (f *Feature) DeleteResources(ctx context.Context, t T) {
 		err = dc.Resource(resource).Namespace(ref.Namespace).Delete(ctx, ref.Name, *deleteOptions)
 		// Ignore not found errors.
 		if err != nil && !apierrors.IsNotFound(err) {
-			refFailedDeletion = append(refFailedDeletion, ref)
 			t.Logf("Warning, failed to delete %s/%s of GVR: %+v: %v", ref.Namespace, ref.Name, resource, err)
 		}
 	}
+
+	// refFailedDeletion keeps the failed to delete resources.
+	var refFailedDeletion []corev1.ObjectReference
+
+	err := wait.Poll(time.Second, 4*time.Minute, func() (bool, error) {
+		refFailedDeletion = nil // Reset failed deletion.
+		for _, ref := range f.References() {
+			gv, err := schema.ParseGroupVersion(ref.APIVersion)
+			if err != nil {
+				t.Fatalf("Could not parse GroupVersion for %+v", ref.APIVersion)
+			}
+
+			resource := apis.KindToResource(gv.WithKind(ref.Kind))
+			t.Logf("Deleting %s/%s of GVR: %+v", ref.Namespace, ref.Name, resource)
+
+			_, err = dc.Resource(resource).
+				Namespace(ref.Namespace).
+				Get(ctx, ref.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				refFailedDeletion = append(refFailedDeletion, ref)
+				return false, fmt.Errorf("failed to get resource %+v %s/%s: %w", resource, ref.Namespace, ref.Name, err)
+			}
+
+			t.Logf("Resource %+v %s/%s still present", resource, ref.Namespace, ref.Name)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		LogReferences(refFailedDeletion...)(ctx, t)
+		t.Fatalf("failed to wait for resources to be deleted: %v", err)
+	}
+
 	f.refs = refFailedDeletion
 }
 

--- a/pkg/feature/logging.go
+++ b/pkg/feature/logging.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/injection/clients/dynamicclient"
+)
+
+func LogReferences(refs ...corev1.ObjectReference) StepFn {
+	return func(ctx context.Context, t T) {
+		for _, ref := range refs {
+			logReference(ref)(ctx, t)
+		}
+	}
+}
+
+func logReference(ref corev1.ObjectReference) StepFn {
+	return func(ctx context.Context, t T) {
+		dc := dynamicclient.Get(ctx)
+
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			t.Fatalf("Could not parse GroupVersion for %+v", ref.APIVersion)
+		}
+
+		resource := apis.KindToResource(gv.WithKind(ref.Kind))
+
+		resourceStr := fmt.Sprintf("Resource %+v %s/%s", resource, ref.Namespace, ref.Name)
+
+		r, err := dc.Resource(resource).
+			Namespace(ref.Namespace).
+			Get(ctx, ref.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Logf("%s not found: %v\n", resourceStr, err)
+			return
+		}
+		if err != nil {
+			t.Logf("%s: %v\n", resourceStr, err)
+			return
+		}
+
+		b, err := json.MarshalIndent(r, "", " ")
+		if err != nil {
+			t.Logf("Failed to marshal %s: %v\n", resourceStr, err)
+			return
+		}
+
+		t.Logf("%s\n%s", resourceStr, string(b))
+
+		// Recursively log owners
+		for _, or := range r.GetOwnerReferences() {
+			t.Logf("Logging owner for %s\n", resourceStr)
+			logReference(corev1.ObjectReference{
+				Kind:       or.Kind,
+				Namespace:  r.GetNamespace(),
+				Name:       or.Name,
+				APIVersion: or.APIVersion,
+			})
+		}
+	}
+}


### PR DESCRIPTION
This patch makes the method `f.DeleteResources` semantic more
clear by waiting for all resources to be deleted before returning.

This guarantees that once a feature passed to a next phase
resources were actually deleted.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>