### PR TITLE
Add EventHub readiness probe only in the receiver role

### DIFF
--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -26,10 +26,12 @@ spec:
     - name: eventshub
       image: {{ .image }}
       imagePullPolicy: "IfNotPresent"
+      {{ if .withReadiness }}
       readinessProbe:
         httpGet:
           port: 8080
           path: /health/ready
+      {{ end }}
       env:
         - name: "SYSTEM_NAMESPACE"
           valueFrom:

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -34,9 +34,10 @@ func Example() {
 		"ko://knative.dev/reconciler-test/cmd/eventshub": "uri://a-real-container",
 	}
 	cfg := map[string]interface{}{
-		"name":      "hubhub",
-		"namespace": "example",
-		"image":     "ko://knative.dev/reconciler-test/cmd/eventshub",
+		"name":          "hubhub",
+		"namespace":     "example",
+		"image":         "ko://knative.dev/reconciler-test/cmd/eventshub",
+		"withReadiness": true,
 		"envs": map[string]string{
 			"foo": "bar",
 			"baz": "boof",
@@ -81,6 +82,71 @@ func Example() {
 	//         httpGet:
 	//           port: 8080
 	//           path: /health/ready
+	//       env:
+	//         - name: "SYSTEM_NAMESPACE"
+	//           valueFrom:
+	//             fieldRef:
+	//               fieldPath: "metadata.namespace"
+	//         - name: "POD_NAME"
+	//           valueFrom:
+	//             fieldRef:
+	//               fieldPath: "metadata.name"
+	//         - name: "EVENT_LOGS"
+	//           value: "recorder,logger"
+	//         - name: "baz"
+	//           value: "boof"
+	//         - name: "foo"
+	//           value: "bar"
+}
+
+func ExampleNoReadiness() {
+	images := map[string]string{
+		"ko://knative.dev/reconciler-test/cmd/eventshub": "uri://a-real-container",
+	}
+	cfg := map[string]interface{}{
+		"name":      "hubhub",
+		"namespace": "example",
+		"image":     "ko://knative.dev/reconciler-test/cmd/eventshub",
+		"envs": map[string]string{
+			"foo": "bar",
+			"baz": "boof",
+		},
+	}
+
+	files, err := manifest.ExecuteYAML(templates, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: Service
+	// metadata:
+	//   name: hubhub
+	//   namespace: example
+	// spec:
+	//   selector:
+	//     app: eventshub-hubhub
+	//   ports:
+	//     - protocol: TCP
+	//       port: 80
+	//       targetPort: 8080
+	// ---
+	// apiVersion: v1
+	// kind: Pod
+	// metadata:
+	//   name: hubhub
+	//   namespace: example
+	//   labels:
+	//     app: eventshub-hubhub
+	// spec:
+	//   serviceAccountName: "example"
+	//   restartPolicy: "Never"
+	//   containers:
+	//     - name: eventshub
+	//       image: uri://a-real-container
+	//       imagePullPolicy: "IfNotPresent"
 	//       env:
 	//         - name: "SYSTEM_NAMESPACE"
 	//           valueFrom:


### PR DESCRIPTION
Senders don't start any server to receive readiness probes.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add EventHub readiness probe only in the receiver role

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #301 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add EventHub readiness probe only in the receiver role
```
