### PR TITLE
Adds timeout to sender requests. Sender fails on http error

### DIFF
--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -180,7 +180,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs) error {
 		}
 		res, err := httpClient.Do(req)
 		if err != nil || res.StatusCode >= 300 {
-			return fmt.Errorf("http error occurred. err: %w, status code: %d", err, res.StatusCode)
+			logging.FromContext(ctx).Errorf("http error occurred. err: %w, status code: %d", err, res.StatusCode)
 		}
 
 		// Publish sent event info


### PR DESCRIPTION
# Changes
- 🧹  Sender uses a timeout when sending events.
- 🧹  Sender will log error if an http error occurs when sending events

We saw a couple of instances where errors will happen in the sender and the test will silently continue onto the next step. With these changes, the hope is it will fail earlier with a more debuggable error.
