### PR TITLE
Remove calling ExecuteLocalYAML func, b/c it is deprecated

### DIFF
--- a/pkg/manifest/templates.go
+++ b/pkg/manifest/templates.go
@@ -23,10 +23,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"text/template"
@@ -157,17 +155,6 @@ func templatesToTmp(files map[string]string, err error) (string, error) {
 // ExecuteYAML process the templates found in files named "*.yaml" and return the f.
 func ExecuteYAML(fsys fs.FS, images map[string]string, cfg map[string]interface{}) (map[string]string, error) {
 	return executeTemplatesFS(fsys, "yaml", images, cfg)
-}
-
-// ExecuteLocalYAML will look in the callers filesystem and process the
-// templates found in files named "*.yaml" and return the f.
-// Deprecated: Use ExecuteYAML instead.
-func ExecuteLocalYAML(images map[string]string, cfg map[string]interface{}) (map[string]string, error) {
-	pwd, _ := os.Getwd()
-	log.Println("PWD: ", pwd)
-	_, filename, _, _ := runtime.Caller(1)
-
-	return ExecuteTemplates(path.Dir(filename), "yaml", images, cfg)
 }
 
 func removeBlanks(in string) string {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Remove calling ExecuteLocalYAML func, b/c it is deprecated

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Removed ExecuteLocalYAML func, since it was deprecated.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
