### PR TITLE
Bump kind to v0.14 for e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         go-version: [ 1.17.x ]
         platform: [ ubuntu-latest ]
-        ko-version: [ 0.8.1 ]
-        kind-version: [ 0.11.1 ]
+        ko-version: [ 0.11.2 ]
+        kind-version: [ 0.14.0 ]
 
     name: e2e tests
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Since we will probably be supporting Kubernetes v1.24 in the next release, and kind v0.13.0+ is required to run Kubernetes v1.24.0+ images, let's go ahead and bump the kind version now, so we have a chance to work out any issues before the next release.

Also bumping the ko version, since we were a few behind here.