### PR TITLE
Dump collected events on failed matches

### DIFF
--- a/pkg/eventshub/event_info_store.go
+++ b/pkg/eventshub/event_info_store.go
@@ -209,12 +209,13 @@ func (ei *Store) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]EventInfo, er
 		count := len(allMatch)
 		if count < min {
 			internalErr = fmt.Errorf(
-				"FAIL MATCHING: saw %d/%d matching events.\n- Store-\n%s\n- Recent events -\n%s\n- Match errors -\n%s\n",
+				"FAIL MATCHING: saw %d/%d matching events.\n- Store-\n%s\n- Recent events -\n%s\n- Match errors -\n%s\nCollected events: %s",
 				count,
 				min,
 				ei.getDebugInfo(),
 				&sInfo,
 				formatErrors(matchErrs),
+				ei.dumpCollected(),
 			)
 			return false, nil
 		}
@@ -223,6 +224,15 @@ func (ei *Store) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]EventInfo, er
 		return true, nil
 	})
 	return matchRet, internalErr
+}
+
+func (ei *Store) dumpCollected() string {
+	var sb strings.Builder
+	for _, e := range ei.Collected() {
+		sb.WriteString(e.String())
+		sb.WriteRune('\n')
+	}
+	return sb.String()
 }
 
 func formatErrors(errs []error) string {


### PR DESCRIPTION
Debugging failed matches is complicated as it is without getting
all events that were collected.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>