### PR TITLE
Fix String() call on nil events on event sender

### DIFF
--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -179,9 +179,13 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...Option)
 			return err
 		}
 
+		eventString := ""
+		if event != nil {
+			eventString = event.String()
+		}
 		span.AddAttributes(
 			trace.StringAttribute("namespace", env.SystemNamespace),
-			trace.StringAttribute("event", event.String()),
+			trace.StringAttribute("event", eventString),
 		)
 
 		res, err := httpClient.Do(req)

--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -179,7 +179,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...Option)
 			return err
 		}
 
-		eventString := ""
+		eventString := "unknown"
 		if event != nil {
 			eventString = event.String()
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🐛  with the new ce checks on the broker conformance test suite sometimes… there are nil events here that are trying to get converted to string, this is a nil check to avoid the event source to error during the test runs


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->