### PR TITLE
Copies an optional image pull secret to service account of new namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,3 +508,8 @@ Run all instances of Noop feature, including instances in a Feature Set
 ```shell
 go test -v -count=1 -tags=e2e ./test/... --feature=Noop
 ```
+
+#### Using Private Registries
+
+If a private registry is to be used with authentication, a Secret needs to be created in the `default` namespace called `kn-test-image-pull-secret` with the credentials.
+The testing framework will copy this secret into any new namespaces created and will update the default ServiceAccount's imagePullSecret.

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -28,7 +28,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
-const testPullSecretName = "kn-eventing-test-pull-secret"
+const testPullSecretName = "kn-test-image-pull-secret"
 
 // CreateNamespaceIfNeeded creates a new namespace if it does not exist.
 func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {


### PR DESCRIPTION
- Can be configured with an EnvOpt. By default will look for `default/kn-test-image-pull-secret`

/kind enhancement

```release-note
- Private registries can now be used for testing.
```

