### PR TITLE
Run steps with the same timing in parallel as documented

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -2,21 +2,24 @@ package environment
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-func categorizeSteps(steps []feature.Step) map[feature.Timing][]feature.Step {
-	res := make(map[feature.Timing][]feature.Step, 4)
+type CategorizedSteps struct {
+	Timing feature.Timing `json:"timing"`
+	Steps  []feature.Step `json:"steps"`
+}
 
-	res[feature.Setup] = filterStepTimings(steps, feature.Setup)
-	res[feature.Requirement] = filterStepTimings(steps, feature.Requirement)
-	res[feature.Assert] = filterStepTimings(steps, feature.Assert)
-	res[feature.Teardown] = filterStepTimings(steps, feature.Teardown)
+func categorizeSteps(steps []feature.Step) (map[feature.Timing][]feature.Step, []CategorizedSteps) {
+	stepsByTiming := make(map[feature.Timing][]feature.Step, 4)
 
-	return res
+	for _, timing := range feature.Timings() {
+		stepsByTiming[timing] = filterStepTimings(steps, timing)
+	}
+
+	return stepsByTiming, stepsSorter(stepsByTiming).byTiming()
 }
 
 func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.Step {
@@ -29,56 +32,52 @@ func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.St
 	return res
 }
 
-// executeWithSkippingT executes the step in a sub test wrapping t in order to never fail the subtest
-// This blocks until the test completes.
-func (mr *MagicEnvironment) executeWithSkippingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
-	originalT.Helper()
-	return mr.executeStep(ctx, originalT, f, s, createSkippingT)
+func (mr *MagicEnvironment) executeOptional(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step) {
+	t.Helper()
+	mr.executeStep(ctx, t, f, s, createSkippingT)
 }
 
-// executeWithoutWrappingT executes the step in a sub test without wrapping t.
-// This blocks until the test completes.
-func (mr *MagicEnvironment) executeWithoutWrappingT(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step) feature.T {
-	originalT.Helper()
-	return mr.executeStep(ctx, originalT, f, s, func(t *testing.T) feature.T {
-		return t
-	})
+// execute executes the step in a sub test without wrapping t.
+func (mr *MagicEnvironment) execute(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step) {
+	t.Helper()
+	mr.executeStep(ctx, t, f, s, func(t *testing.T) feature.T { return t })
 }
 
-func (mr *MagicEnvironment) executeStep(ctx context.Context, originalT *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) feature.T {
-	originalT.Helper()
+func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) {
+	t.Helper()
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
-	var internalT feature.T
-	originalT.Run(f.Name+"/"+s.T.String()+"/"+s.TestName(), func(st *testing.T) {
-		st.Helper()
-		internalT = tDecorator(st)
+	t.Run(s.Name, func(t *testing.T) {
+		t.Parallel()
+		t.Helper()
+		ft := tDecorator(t)
+		t.Cleanup(func() {
+			mr.milestones.StepFinished(f.Name, s, ft)
+		})
 
 		// Create a cancel tied to this step
 		internalCtx, internalCancelFn := context.WithCancel(ctx)
 
 		defer func() {
 			if r := recover(); r != nil {
-				internalT.Errorf("Panic happened: '%v'", r)
+				ft.Errorf("Panic happened: '%v'", r)
 			}
 			// Close the context as soon as possible (this defer is invoked before the Cleanup)
 			internalCancelFn()
 		}()
 
-		mr.milestones.StepStarted(f.Name, s, internalT)
-		internalT.Cleanup(func() {
-			mr.milestones.StepFinished(f.Name, s, internalT)
-			wg.Done() // Make sure wg.Done() is invoked at the very end of the execution
-		})
+		mr.milestones.StepStarted(f.Name, s, ft)
 
 		// Perform step.
-		s.Fn(internalCtx, internalT)
+		s.Fn(internalCtx, ft)
 	})
+}
 
-	// Wait for the test to execute before spawning the next one
-	wg.Wait()
+type stepsSorter map[feature.Timing][]feature.Step
 
-	return internalT
+func (ss stepsSorter) byTiming() []CategorizedSteps {
+	cs := make([]CategorizedSteps, len(feature.Timings()))
+	for timing, steps := range ss {
+		cs[timing] = CategorizedSteps{Timing: timing, Steps: steps}
+	}
+	return cs
 }

--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -7,19 +7,14 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-type CategorizedSteps struct {
-	Timing feature.Timing `json:"timing"`
-	Steps  []feature.Step `json:"steps"`
-}
-
-func categorizeSteps(steps []feature.Step) (map[feature.Timing][]feature.Step, []CategorizedSteps) {
+func categorizeSteps(steps []feature.Step) map[feature.Timing][]feature.Step {
 	stepsByTiming := make(map[feature.Timing][]feature.Step, 4)
 
 	for _, timing := range feature.Timings() {
 		stepsByTiming[timing] = filterStepTimings(steps, timing)
 	}
 
-	return stepsByTiming, stepsSorter(stepsByTiming).byTiming()
+	return stepsByTiming
 }
 
 func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.Step {
@@ -70,14 +65,4 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *fe
 		// Perform step.
 		s.Fn(internalCtx, ft)
 	})
-}
-
-type stepsSorter map[feature.Timing][]feature.Step
-
-func (ss stepsSorter) byTiming() []CategorizedSteps {
-	cs := make([]CategorizedSteps, len(feature.Timings()))
-	for timing, steps := range ss {
-		cs[timing] = CategorizedSteps{Timing: timing, Steps: steps}
-	}
-	return cs
 }

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/injection/clients/dynamicclient"
+
 	"knative.dev/reconciler-test/pkg/state"
 )
 
@@ -116,6 +117,13 @@ type Step struct {
 	L    Levels `json:"levels"`
 	T    Timing `json:"timing"`
 	Fn   StepFn `json:"-"`
+}
+
+type Steps []Step
+
+func (ss Steps) String() string {
+	bytes, _ := json.MarshalIndent(ss, "", "  ")
+	return string(bytes)
 }
 
 // TestName returns the constructed test name based on the timing, step, state,

--- a/test/e2e/environment_fails_test.go
+++ b/test/e2e/environment_fails_test.go
@@ -77,7 +77,6 @@ func TestRequirementFail(t *testing.T) {
 
 	env.Test(ctx, t, feat)
 
-	require.Equal(t, "setup1setup2setup3requirement1teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
 }
 
@@ -125,7 +124,6 @@ func TestFailingSetupSkipsToTeardownSkip(t *testing.T) {
 
 	env.Test(ctx, t, feat)
 
-	require.Equal(t, "setup1setup2teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(0), atomic.LoadInt32(&counter))
 }
 
@@ -193,7 +191,6 @@ func TestPanicContinuesTheExecutionOfAssertions(t *testing.T) {
 
 	env.Test(ctx, t, feat)
 
-	require.Equal(t, "setup1setup2setup3teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(2), atomic.LoadInt32(&counter))
 }
 
@@ -233,6 +230,5 @@ func TestFatalContinuesTheExecutionOfAssertions(t *testing.T) {
 
 	env.Test(ctx, t, feat)
 
-	require.Equal(t, "setup1setup2setup3teardown1teardown2teardown3", stringBuilder.String())
 	require.Equal(t, int32(2), atomic.LoadInt32(&counter))
 }

--- a/test/example/prober_feature.go
+++ b/test/example/prober_feature.go
@@ -41,9 +41,7 @@ func ProberFeature() *feature.Feature {
 	prober.AsKReference(to)
 	_ = prober.SetTargetKRef(prober.AsKReference(to))
 
-	f.Setup("install sender", prober.SenderInstall(from))
-	f.Requirement("sender is done", prober.SenderDone(from))
-	f.Requirement("receiver is done", prober.ReceiverDone(from, to))
+	f.Requirement("install sender", prober.SenderInstall(from))
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the sender sent all events", prober.AssertSentAll(from)).
@@ -71,9 +69,7 @@ func ProberFeatureWithDrop() *feature.Feature {
 	prober.AsKReference(to)
 	_ = prober.SetTargetKRef(prober.AsKReference(to))
 
-	f.Setup("install sender", prober.SenderInstall(from))
-	f.Requirement("sender is done", prober.SenderDone(from))
-	f.Requirement("receiver is done", prober.ReceiverDone(from, to))
+	f.Requirement("install sender", prober.SenderInstall(from))
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the sender sent all events", func(ctx context.Context, t feature.T) {
@@ -119,10 +115,7 @@ func ProberFeatureYAML() *feature.Feature {
 	// Configured the Sender to send the same events.
 	prober.SenderEventsFromURI("https://raw.githubusercontent.com/cloudevents/conformance/v0.2.0/yaml/v1.0/v1_minimum.yaml")
 
-	f.Setup("install sender with yaml events", prober.SenderInstall(from))
-
-	f.Requirement("sender is done", prober.SenderDone(from))
-	f.Requirement("receiver is done", prober.ReceiverDone(from, to))
+	f.Requirement("install sender with yaml events", prober.SenderInstall(from))
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the sender sent all events", prober.AssertSentAll(from)).

--- a/test/example/recorder_feature.go
+++ b/test/example/recorder_feature.go
@@ -20,52 +20,33 @@ import (
 	"context"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/pkg/state"
 	"knative.dev/reconciler-test/resources/svc"
 
 	// Dot import the eventshub asserts and sdk-go test packages to include all the assert utilities
 	. "github.com/cloudevents/sdk-go/v2/test"
+
 	. "knative.dev/reconciler-test/pkg/eventshub/assert"
 )
 
 func RecorderFeature() *feature.Feature {
 	f := &feature.Feature{Name: "Record"}
 
-	f.Setup("create an event", func(ctx context.Context, t feature.T) {
-		state.SetOrFail(ctx, t, "event", FullEvent())
-	})
+	to := feature.MakeRandomK8sName("recorder")
+	from := feature.MakeRandomK8sName("sender")
+	event := FullEvent()
 
-	f.Setup("install recorder", func(ctx context.Context, t feature.T) {
-		to := feature.MakeRandomK8sName("recorder")
-		state.SetOrFail(ctx, t, "to", to)
-		eventshub.Install(to, eventshub.StartReceiver)(ctx, t)
-	})
+	f.Setup("install recorder", eventshub.Install(to, eventshub.StartReceiver))
+	f.Setup("recorder is addressable", k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second))
 
-	f.Setup("install sender", func(ctx context.Context, t feature.T) {
-		to := state.GetStringOrFail(ctx, t, "to")
-		var event cloudevents.Event
-		state.GetOrFail(ctx, t, "event", &event)
-		from := feature.MakeRandomK8sName("sender")
-		eventshub.Install(from, eventshub.StartSender(to), eventshub.InputEvent(event))(ctx, t)
-	})
-
-	f.Requirement("recorder is addressable", func(ctx context.Context, t feature.T) {
-		to := state.GetStringOrFail(ctx, t, "to")
-		k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second)(ctx, t)
-	})
+	f.Requirement("install sender", eventshub.Install(from, eventshub.StartSender(to), eventshub.InputEvent(event)))
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the recorder received all sent events within the time",
-			func(ctx context.Context, t feature.T) {
-				to := state.GetStringOrFail(ctx, t, "to")
-				var event cloudevents.Event
-				state.GetOrFail(ctx, t, "event", &event)
-				OnStore(to).MatchEvent(HasId(event.ID())).Exact(1)(ctx, t)
-			})
+			OnStore(to).MatchEvent(HasId(event.ID())).Exact(1),
+		)
 
 	return f
 }
@@ -73,28 +54,20 @@ func RecorderFeature() *feature.Feature {
 func RecorderFeatureYAML() *feature.Feature {
 	f := &feature.Feature{Name: "Record"}
 
-	f.Setup("install recorder", func(ctx context.Context, t feature.T) {
-		to := feature.MakeRandomK8sName("recorder")
-		state.SetOrFail(ctx, t, "to", to)
-		eventshub.Install(to, eventshub.StartReceiver)(ctx, t)
-	})
+	to := feature.MakeRandomK8sName("recorder")
+	from := feature.MakeRandomK8sName("sender")
 
-	f.Setup("install sender with yaml events", func(ctx context.Context, t feature.T) {
-		to := state.GetStringOrFail(ctx, t, "to")
-		from := feature.MakeRandomK8sName("sender")
-		eventshub.Install(from, eventshub.StartSender(to),
-			eventshub.InputYAML("https://raw.githubusercontent.com/cloudevents/conformance/v0.2.0/yaml/v1.0/v1_minimum.yaml"))(ctx, t)
-	})
+	f.Setup("install recorder", eventshub.Install(to, eventshub.StartReceiver))
+	f.Setup("recorder is addressable", k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second))
 
-	f.Requirement("recorder is addressable", func(ctx context.Context, t feature.T) {
-		to := state.GetStringOrFail(ctx, t, "to")
-		k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second)
-	})
+	f.Requirement("install sender with yaml events", eventshub.Install(from,
+		eventshub.StartSender(to),
+		eventshub.InputYAML("https://raw.githubusercontent.com/cloudevents/conformance/v0.2.0/yaml/v1.0/v1_minimum.yaml"),
+	))
 
 	f.Alpha("direct sending between a producer and a recorder").
 		Must("the recorder received all sent events within the time",
 			func(ctx context.Context, t feature.T) {
-				to := state.GetStringOrFail(ctx, t, "to")
 				OnStore(to).MatchEvent(HasId("conformance-0001")).Exact(1)(ctx, t)
 				OnStore(to).MatchEvent(HasId("conformance-0002")).Exact(1)(ctx, t)
 				OnStore(to).MatchEvent(HasId("conformance-0003")).Exact(1)(ctx, t)


### PR DESCRIPTION
The `README` is explicity documenting that timings
(Setup, Requirement, etc) runs in order but steps with the
same timing runs in parallel while currently, this is not the
case and it is slowing test execution time down.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Run steps with the same timing in parallel

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Run steps with the same timing in parallel as documented.
```
