### PR TITLE
Fix data race on publish images

### DIFF
--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"knative.dev/pkg/logging"
+
 	"knative.dev/reconciler-test/pkg/images/ko"
 )
 
@@ -90,7 +91,7 @@ func ProduceImages(ctx context.Context) (map[string]string, error) {
 		}
 		store.refs[koPack] = strings.TrimSpace(image)
 	}
-	return store.refs, nil
+	return store.copyRefs(), nil
 }
 
 func initializeImageStores(ctx context.Context) context.Context {
@@ -160,4 +161,12 @@ func (k imageStoreKey) get(ctx context.Context) *imageStore {
 
 type imageStore struct {
 	refs map[string]string
+}
+
+func (is imageStore) copyRefs() map[string]string {
+	refs := make(map[string]string, len(is.refs))
+	for k, v := range is.refs {
+		refs[k] = v
+	}
+	return refs
 }

--- a/pkg/environment/images_test.go
+++ b/pkg/environment/images_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package environment
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProduceImages(t *testing.T) {
+
+	ctx := context.Background()
+
+	readImages := func(images map[string]string) string {
+		return images["x"]
+	}
+	writeImages := func(images map[string]string) {
+		images["x"] = "x"
+	}
+
+	ctx, err := WithImages(map[string]string{
+		"y": "y",
+	})(ctx, nil)
+	require.Nil(t, err)
+
+	var wg sync.WaitGroup
+	for x := 0; x < 100; x++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			images, err := ProduceImages(ctx)
+			require.Nil(t, err)
+			writeImages(images)
+			i := readImages(images)
+			t.Log("Image", i)
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
If you uncomment the `copyRefs` code and just return the shared `is.refs` you will get:
`"Race detected during the execution of the test"` while executing the added test.

`go test -race -count=5 ./pkg/environment/...`

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- copy image store map for read-only access

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #410 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix data race on publish images.
```
