### PR TITLE
Fix prober concurrent access

### DIFF
--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -44,14 +44,20 @@ func NewProber() *EventProber {
 }
 
 type EventProber struct {
-	target target
+	target   target
+	targetMu sync.Mutex
 
 	shortNameToName   map[string]string
-	shortNameToNameMu sync.RWMutex
+	shortNameToNameMu sync.Mutex
 
-	ids             []string
+	ids   []string
+	idsMu sync.Mutex
+
 	senderOptions   []EventsHubOption
-	receiverOptions []EventsHubOption
+	senderOptionsMu sync.Mutex
+
+	receiverOptions   []EventsHubOption
+	receiverOptionsMu sync.Mutex
 }
 
 type target struct {
@@ -68,6 +74,9 @@ type EventInfoCombined struct {
 
 // SetTargetResource configures the senders target as a GVR and name, used when sender is installed.
 func (p *EventProber) SetTargetResource(targetGVR schema.GroupVersionResource, targetName string) {
+	p.targetMu.Lock()
+	defer p.targetMu.Unlock()
+
 	p.target = target{
 		gvr:  targetGVR,
 		name: targetName,
@@ -87,15 +96,15 @@ func (p *EventProber) SetTargetKRef(ref *duckv1.KReference) error {
 		Kind:    ref.Kind,
 	}
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	p.target = target{
-		gvr:  gvr,
-		name: ref.Name,
-	}
+	p.SetTargetResource(gvr, ref.Name)
 	return nil
 }
 
 // SetTargetURI configures the senders target as a URI, used when sender is installed.
 func (p *EventProber) SetTargetURI(targetURI string) {
+	p.targetMu.Lock()
+	defer p.targetMu.Unlock()
+
 	p.target = target{
 		uri: targetURI,
 	}
@@ -103,28 +112,28 @@ func (p *EventProber) SetTargetURI(targetURI string) {
 
 // ReceiversRejectFirstN adds DropFirstN to the default config for new receivers.
 func (p *EventProber) ReceiversRejectFirstN(n uint) {
-	p.receiverOptions = append(p.receiverOptions, DropFirstN(n))
+	p.appendReceiverOptions(DropFirstN(n))
 }
 
 // ReceiversRejectResponseCode adds DropEventsResponseCode to the default config for new receivers.
 func (p *EventProber) ReceiversRejectResponseCode(code int) {
-	p.receiverOptions = append(p.receiverOptions, DropEventsResponseCode(code))
+	p.appendReceiverOptions(DropEventsResponseCode(code))
 }
 
 // ReceiversHaveResponseDelay adds ResponseWaitTime to the default config for
 // new receivers.
 func (p *EventProber) ReceiversHaveResponseDelay(delay time.Duration) {
-	p.receiverOptions = append(p.receiverOptions, ResponseWaitTime(delay))
+	p.appendReceiverOptions(ResponseWaitTime(delay))
 }
 
 // ReceiverInstall installs an eventshub receiver into the test env.
 func (p *EventProber) ReceiverInstall(prefix string, opts ...EventsHubOption) feature.StepFn {
 	name := feature.MakeRandomK8sName(prefix)
 	p.setShortNameToName(prefix, name)
+	p.appendReceiverOptions(opts...)
+	p.appendReceiverOptions(StartReceiver)
 
-	opts = append(p.receiverOptions, opts...)
-	opts = append(opts, StartReceiver)
-	return Install(name, opts...)
+	return Install(name, p.getReceiverOptions()...)
 }
 
 // SenderInstall installs an eventshub sender resource into the test env.
@@ -133,11 +142,11 @@ func (p *EventProber) SenderInstall(prefix string, opts ...EventsHubOption) feat
 	p.setShortNameToName(prefix, name)
 
 	return func(ctx context.Context, t feature.T) {
-		opts := append(opts, p.senderOptions...)
-		if len(p.target.uri) > 0 {
-			opts = append(opts, StartSenderURL(p.target.uri))
-		} else if !p.target.gvr.Empty() {
-			opts = append(opts, StartSenderToResource(p.target.gvr, p.target.name))
+		opts := append(opts, p.getSenderOptions()...)
+		if len(p.getTarget().uri) > 0 {
+			opts = append(opts, StartSenderURL(p.getTarget().uri))
+		} else if !p.getTarget().gvr.Empty() {
+			opts = append(opts, StartSenderToResource(p.getTarget().gvr, p.getTarget().name))
 		} else {
 			t.Fatal("no target is configured for event loop")
 		}
@@ -154,9 +163,10 @@ func (p *EventProber) SenderDone(prefix string) feature.StepFn {
 		interval, timeout := environment.PollTimingsFromContext(ctx)
 		var events []EventInfoCombined
 		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			expected := p.getIdsCopy()
 			events = p.SentBy(ctx, prefix)
-			t.Log(p.getNameFromPrefix(prefix), "has sent", len(events))
-			if len(events) == len(p.ids) {
+			t.Log(p.getNameFromPrefix(prefix), "has sent", len(events), "expected", len(expected))
+			if len(events) == len(expected) {
 				return true, nil
 			}
 			return false, nil
@@ -289,19 +299,19 @@ func (p *EventProber) ExpectYAMLEvents(path string) error {
 		return fmt.Errorf("failed to load events from %q", path)
 	}
 	for _, event := range events {
-		p.ids = append(p.ids, event.Attributes.ID)
+		p.appendIds(event.Attributes.ID)
 	}
 	return nil
 }
 
 // ExpectEvents registers event IDs into the prober.
 func (p *EventProber) ExpectEvents(ids []string) {
-	p.ids = append(p.ids, ids...)
+	p.appendIds(ids...)
 }
 
 // SenderEventsFromURI configures a sender to send a url/yaml based events.
 func (p *EventProber) SenderEventsFromURI(uri string) {
-	p.senderOptions = append(p.senderOptions, InputYAML(uri))
+	p.appendSenderOptions(InputYAML(uri))
 }
 
 // SenderEventsFromSVC configures a sender to send a yaml based events fetched
@@ -314,7 +324,7 @@ func (p *EventProber) SenderEventsFromSVC(svcName, path string) feature.StepFn {
 			t.Error(err)
 		}
 		u.Path = path
-		p.senderOptions = append(p.senderOptions, InputYAML(u.String()))
+		p.appendSenderOptions(InputYAML(u.String()))
 	}
 }
 
@@ -326,14 +336,16 @@ func (p *EventProber) SenderFullEvents(count int) {
 	if count == 1 {
 		id := uuid.New().String()
 		event.SetID(id)
-		p.ids = []string{id}
-		p.senderOptions = append(p.senderOptions, InputEvent(event))
+		p.appendIds(id)
+		p.appendSenderOptions(InputEvent(event))
 	} else {
-		p.senderOptions = append(p.senderOptions,
-			InputEvent(event), SendMultipleEvents(count, 10*time.Millisecond), EnableIncrementalId) // TODO: make configurable.
-		p.ids = []string{}
+		p.appendSenderOptions(
+			InputEvent(event),
+			SendMultipleEvents(count, 10*time.Millisecond),
+			EnableIncrementalId,
+		)
 		for i := 1; i <= count; i++ {
-			p.ids = append(p.ids, strconv.Itoa(i))
+			p.appendIds(strconv.Itoa(i))
 		}
 	}
 }
@@ -346,13 +358,12 @@ func (p *EventProber) SenderMinEvents(count int) {
 	if count == 1 {
 		id := uuid.New().String()
 		event.SetID(id)
-		p.ids = []string{id}
-		p.senderOptions = append(p.senderOptions, InputEvent(event))
+		p.appendIds(id)
+		p.appendSenderOptions(InputEvent(event))
 	} else {
-		p.senderOptions = append(p.senderOptions, InputEvent(event), SendMultipleEvents(count, 10*time.Millisecond)) // TODO: make configurable.
-		p.ids = []string{}
+		p.appendSenderOptions(InputEvent(event), SendMultipleEvents(count, 10*time.Millisecond))
 		for i := 1; i <= count; i++ {
-			p.ids = append(p.ids, strconv.Itoa(i))
+			p.appendIds(strconv.Itoa(i))
 		}
 	}
 }
@@ -368,11 +379,12 @@ func (p *EventProber) AssertSentAll(fromPrefix string) feature.StepFn {
 		p.SenderDone(fromPrefix)(ctx, t)
 
 		events := p.SentBy(ctx, fromPrefix)
-		if len(p.ids) != len(events) {
+		expected := p.getIdsCopy()
+		if len(expected) != len(events) {
 			t.Errorf("expected %q to have sent %d events, actually sent %d",
-				fromPrefix, len(p.ids), len(events))
+				fromPrefix, len(expected), len(events))
 		}
-		for _, id := range p.ids {
+		for _, id := range expected {
 			found := false
 			for _, event := range events {
 				if id == event.Sent.SentId {
@@ -488,8 +500,68 @@ func (p *EventProber) setShortNameToName(k, v string) {
 }
 
 func (p *EventProber) getNameFromPrefix(prefix string) string {
-	p.shortNameToNameMu.RLock()
-	defer p.shortNameToNameMu.RUnlock()
+	p.shortNameToNameMu.Lock()
+	defer p.shortNameToNameMu.Unlock()
 
 	return p.shortNameToName[prefix]
+}
+
+func (p *EventProber) getSenderOptions() []EventsHubOption {
+	p.senderOptionsMu.Lock()
+	defer p.senderOptionsMu.Unlock()
+
+	return p.senderOptions
+}
+
+func (p *EventProber) getReceiverOptions() []EventsHubOption {
+	p.receiverOptionsMu.Lock()
+	defer p.receiverOptionsMu.Unlock()
+
+	return p.receiverOptions
+}
+
+func (p *EventProber) appendReceiverOptions(opt ...EventsHubOption) {
+	p.receiverOptionsMu.Lock()
+	defer p.receiverOptionsMu.Unlock()
+
+	p.receiverOptions = append(p.receiverOptions, opt...)
+}
+
+func (p *EventProber) appendSenderOptions(opt ...EventsHubOption) {
+	p.senderOptionsMu.Lock()
+	defer p.senderOptionsMu.Unlock()
+
+	p.senderOptions = append(p.senderOptions, opt...)
+}
+
+func (p *EventProber) appendIds(ids ...string) {
+	p.idsMu.Lock()
+	defer p.idsMu.Unlock()
+
+	p.ids = append(p.ids, ids...)
+}
+
+func (p *EventProber) getIdsCopy() []string {
+	p.idsMu.Lock()
+	defer p.idsMu.Unlock()
+
+	ids := make([]string, len(p.ids))
+	copy(ids, p.ids)
+	return ids
+}
+
+func (p *EventProber) getTarget() target {
+	p.targetMu.Lock()
+	defer p.targetMu.Unlock()
+
+	return p.target
+}
+
+func (p *EventProber) DumpState(ctx context.Context, t feature.T) {
+	p.shortNameToNameMu.Lock()
+	defer p.shortNameToNameMu.Unlock()
+
+	for k, v := range p.shortNameToName {
+		t.Logf("collected for %s (%s)\n", v, k, StoreFromContext(ctx, v).dumpCollected())
+	}
 }

--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -36,8 +36,10 @@ import (
 	"github.com/cloudevents/sdk-go/v2/types"
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/logging"
+
 	"knative.dev/reconciler-test/pkg/eventshub"
 )
 
@@ -144,6 +146,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...Option)
 			}
 
 			if _, err := nethttp.DefaultClient.Do(req); err != nil {
+				logging.FromContext(ctx).Error(zap.Error(err))
 				return false, nil
 			}
 			return true, nil

--- a/test/example/prober_feature.go
+++ b/test/example/prober_feature.go
@@ -59,14 +59,11 @@ func ProberFeatureWithDrop() *feature.Feature {
 	prober := eventshub.NewProber()
 	prober.ReceiversRejectFirstN(5)
 	prober.ReceiversRejectResponseCode(429)
-
-	// Configured the sender for how many events it will be sending.
 	prober.SenderFullEvents(6)
 
 	// Install the receiver, then the sender.
 	f.Setup("install recorder", prober.ReceiverInstall(to))
 
-	prober.AsKReference(to)
 	_ = prober.SetTargetKRef(prober.AsKReference(to))
 
 	f.Requirement("install sender", prober.SenderInstall(from))
@@ -89,6 +86,10 @@ func ProberFeatureWithDrop() *feature.Feature {
 						t.Errorf("For %s, expected 2xx response, got %d", event.Sent.SentId, event.Response.StatusCode)
 					}
 				}
+			}
+
+			if t.Failed() {
+				prober.DumpState(ctx, t)
 			}
 		}).
 		Must("the recorder received all sent events", prober.AssertReceivedOrRejectedAll(from, to))


### PR DESCRIPTION
Multiple go routines can access the prober concurrently,
therefore we need to guard its field access with mutexes.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
