### PR TITLE
Handle not found resources while waiting as in WaitForResourceCondition

### DIFF
--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -37,6 +37,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/kmeta"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
@@ -251,6 +252,11 @@ func WaitForServiceEndpoints(ctx context.Context, t feature.T, name string, numb
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		svc, err := services.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Log("service", "namespace", ns, "name", name, err)
+				// keep polling
+				return false, nil
+			}
 			return false, err
 		}
 		ip := svc.Spec.ClusterIP
@@ -374,6 +380,11 @@ func WaitForPodRunningOrFail(ctx context.Context, t feature.T, podName string) {
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		p, err := p.Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Log("pod", "namespace", ns, "name", podName, err)
+				// keep polling
+				return false, nil
+			}
 			return true, err
 		}
 		isRunning := podRunning(p)


### PR DESCRIPTION
As per title, similar to 

https://github.com/knative-sandbox/reconciler-test/blob/a38bc32e26e4dddaa3259b51f6c5176304915321/pkg/k8s/wait.go#L134-L138

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Handle not found resources while waiting as in WaitForResourceCondition