### PR TITLE
Fix prober receiver install options

### DIFF
--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -131,10 +131,10 @@ func (p *EventProber) ReceiversHaveResponseDelay(delay time.Duration) {
 func (p *EventProber) ReceiverInstall(prefix string, opts ...EventsHubOption) feature.StepFn {
 	name := feature.MakeRandomK8sName(prefix)
 	p.setShortNameToName(prefix, name)
-	p.appendReceiverOptions(opts...)
-	p.appendReceiverOptions(StartReceiver)
+	opts = append(opts, p.getReceiverOptions()...)
+	opts = append(opts, StartReceiver)
 
-	return Install(name, p.getReceiverOptions()...)
+	return Install(name, opts...)
 }
 
 // SenderInstall installs an eventshub sender resource into the test env.

--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -131,7 +131,7 @@ func (p *EventProber) ReceiversHaveResponseDelay(delay time.Duration) {
 func (p *EventProber) ReceiverInstall(prefix string, opts ...EventsHubOption) feature.StepFn {
 	name := feature.MakeRandomK8sName(prefix)
 	p.setShortNameToName(prefix, name)
-	opts = append(opts, p.getReceiverOptions()...)
+	opts = append(p.getReceiverOptions(), opts...)
 	opts = append(opts, StartReceiver)
 
 	return Install(name, opts...)


### PR DESCRIPTION
When calling ReceiverInstall options parameter were appended to the the global prober receiver options which causes misconfiguration, evident when using the prober to install different receivers with different configurations.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
