### PR TITLE
Keep polling when endpoint is not present

### DIFF
--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -271,6 +271,11 @@ func WaitForServiceEndpoints(ctx context.Context, t feature.T, name string, numb
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		endpoint, err := endpoints.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Log("endpoint", "namespace", ns, "name", name, err)
+				// keep polling
+				return false, nil
+			}
 			return false, err
 		}
 		num := countEndpointsNum(endpoint)


### PR DESCRIPTION
Endpoints are created asynchronously from the Service creation, so we need to keep polling when endpoints are not present.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
