### PR TITLE
Add helpers to create & interact with a batchv1.Job

### DIFF
--- a/pkg/resources/job/job.go
+++ b/pkg/resources/job/job.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job
+
+import (
+	"context"
+	"embed"
+	"time"
+
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Install(name string, image string, options ...manifest.CfgFn) feature.StepFn {
+	cfg := map[string]interface{}{
+		"name":            name,
+		"image":           image,
+		"imagePullPolicy": "IfNotPresent",
+		"restartPolicy":   "Never",
+	}
+
+	for _, fn := range options {
+		fn(cfg)
+	}
+
+	return func(ctx context.Context, t feature.T) {
+		if err := registerImage(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func IsDone(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobDone(ctx, t, name, timing...); err != nil {
+			t.Error("Job did not turn into done state", err)
+		}
+	}
+}
+
+func IsSucceeded(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobSucceeded(ctx, t, name, timing...); err != nil {
+			t.Error("Job did not succeed", err)
+		}
+	}
+}
+
+func IsFailed(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobFailed(ctx, t, name, timing...); err != nil {
+			t.Error("Job did not fail", err)
+		}
+	}
+}
+
+func registerImage(ctx context.Context) error {
+	im := manifest.ImagesFromFS(ctx, yaml)
+	reg := environment.RegisterPackage(im...)
+	_, err := reg(ctx, environment.FromContext(ctx))
+	return err
+}

--- a/pkg/resources/job/job.go
+++ b/pkg/resources/job/job.go
@@ -21,7 +21,6 @@ import (
 	"embed"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -33,10 +32,8 @@ var yaml embed.FS
 
 func Install(name string, image string, options ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{
-		"name":            name,
-		"image":           image,
-		"imagePullPolicy": corev1.PullIfNotPresent,
-		"restartPolicy":   corev1.RestartPolicyNever,
+		"name":  name,
+		"image": image,
 	}
 
 	for _, fn := range options {
@@ -47,6 +44,7 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 		if err := registerImage(ctx, image); err != nil {
 			t.Fatal(err)
 		}
+		manifest.PodSecurityCfgFn(ctx, t)(cfg)
 		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -5,25 +5,61 @@ metadata:
   namespace: {{ .namespace }}
   {{ if .annotations }}
   annotations:
-  {{ range $key, $value := .annotations }}
+    {{ range $key, $value := .annotations }}
     {{ $key }}: "{{ $value }}"
+    {{ end }}
   {{ end }}
+  {{ if .labels }}
+  labels:
+    {{ range $key, $value := .labels }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
   {{ end }}
 spec:
   {{ if .backoffLimit }}
   backoffLimit: {{ .backoffLimit }}
   {{ end }}
+  {{ if .ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+  {{ end }}
   template:
     spec:
+      {{ if .podSecurityContext }}
+      securityContext:
+        runAsNonRoot: {{ .podSecurityContext.runAsNonRoot }}
+        seccompProfile:
+          type: {{ .podSecurityContext.seccompProfile.type }}
+      {{ end }}
+      {{ if .restartPolicy }}
+      restartPolicy: {{ .restartPolicy }}
+      {{ end }}
       containers:
-      - name: jobcontainer
-        image: "{{ .image }}"
-        imagePullPolicy: "{{ .imagePullPolicy }}"
+      - name: job-container
+        image: {{ .image }}
         {{ if .envs }}
         env:
-          {{ range $key, $value := .envs }}
-          - name: {{ printf "%q" $key }}
-            value: {{ printf "%q" $value }}
-          {{ end }}
+        {{ range $key, $value := .envs }}
+        - name: {{ printf "%q" $key }}
+          value: {{ printf "%q" $value }}
         {{ end }}
-      restartPolicy: "{{ .restartPolicy }}"
+        {{ end }}
+        {{ if .containerSecurityContext }}
+        securityContext:
+          capabilities:
+            {{ if .containerSecurityContext.capabilities.drop }}
+            drop:
+            {{ range $_, $value := .containerSecurityContext.capabilities.drop }}
+            - {{ $value }}
+            {{ end }}
+            {{ end }}
+            {{ if .containerSecurityContext.capabilities.add }}
+            add:
+            {{ range $_, $value := .containerSecurityContext.capabilities.add }}
+            - {{ $value }}
+            {{ end }}
+            {{ end }}
+          allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
+        {{ end }}
+        {{ if .imagePullPolicy }}
+        imagePullPolicy: {{ .imagePullPolicy }}
+        {{ end }}

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  {{ if .annotations }}
+  annotations:
+  {{ range $key, $value := .annotations }}
+    {{ $key }}: "{{ $value }}"
+  {{ end }}
+  {{ end }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: jobcontainer
+        image: "{{ .image }}"
+        imagePullPolicy: "{{ .imagePullPolicy }}"
+        restartPolicy: "{{ .restartPolicy }}"
+        env:
+          {{ range $key, $value := .envs }}
+          - name: {{printf "%q" $key}}
+            value: {{printf "%q" $value}}
+          {{ end }}
+        {{ end }}
+  backoffLimit: 4

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -23,6 +23,21 @@ spec:
   ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
   {{ end }}
   template:
+    {{ if or .podannotations .podlabels }}
+    metadata:
+      {{ if .podannotations }}
+      annotations:
+        {{ range $key, $value := .podannotations }}
+        {{ $key }}: "{{ $value }}"
+        {{ end }}
+      {{ end }}
+      {{ if .podlabels }}
+      labels:
+        {{ range $key, $value := .podlabels }}
+        {{ $key }}: {{ $value }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
     spec:
       {{ if .podSecurityContext }}
       securityContext:

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -19,11 +19,11 @@ spec:
       - name: jobcontainer
         image: "{{ .image }}"
         imagePullPolicy: "{{ .imagePullPolicy }}"
-        restartPolicy: "{{ .restartPolicy }}"
+        {{ if .envs }}
         env:
           {{ range $key, $value := .envs }}
-          - name: {{printf "%q" $key}}
-            value: {{printf "%q" $value}}
+          - name: {{ printf "%q" $key }}
+            value: {{ printf "%q" $value }}
           {{ end }}
         {{ end }}
-  backoffLimit: 4
+      restartPolicy: "{{ .restartPolicy }}"

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -10,6 +10,9 @@ metadata:
   {{ end }}
   {{ end }}
 spec:
+  {{ if .backoffLimit }}
+  backoffLimit: {{ .backoffLimit }}
+  {{ end }}
   template:
     spec:
       containers:

--- a/pkg/resources/job/job_test.go
+++ b/pkg/resources/job/job_test.go
@@ -75,6 +75,12 @@ func Example_full() {
 		job.WithAnnotations(map[string]interface{}{
 			"app.kubernetes.io/name": "app",
 		}),
+		job.WithPodLabels(map[string]string{
+			"app": "my-app",
+		}),
+		job.WithPodAnnotations(map[string]interface{}{
+			"pod-annotation": "foo",
+		}),
 		job.WithRestartPolicy(v1.RestartPolicyNever),
 		job.WithImagePullPolicy(v1.PullNever),
 		job.WithBackoffLimit(20),
@@ -108,6 +114,11 @@ func Example_full() {
 	//   backoffLimit: 20
 	//   ttlSecondsAfterFinished: 30
 	//   template:
+	//     metadata:
+	//       annotations:
+	//         pod-annotation: "foo"
+	//       labels:
+	//         app: my-app
 	//     spec:
 	//       restartPolicy: Never
 	//       containers:
@@ -191,6 +202,40 @@ func Example_WithAnnotations() {
 	//         image: baz
 }
 
+func Example_WithPodAnnotations() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithPodAnnotations(map[string]interface{}{"app.kubernetes.io/name": "app1"})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     metadata:
+	//       annotations:
+	//         app.kubernetes.io/name: "app1"
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
 func Example_WithLabels() {
 	ctx := testlog.NewContext()
 	images := map[string]string{}
@@ -222,6 +267,44 @@ func Example_WithLabels() {
 	//     version: 3
 	// spec:
 	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_WithPodLabels() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithPodLabels(map[string]string{
+		"color":   "blue",
+		"version": "3",
+	})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     metadata:
+	//       labels:
+	//         color: blue
+	//         version: 3
 	//     spec:
 	//       containers:
 	//       - name: job-container

--- a/pkg/resources/job/job_test.go
+++ b/pkg/resources/job/job_test.go
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job_test
+
+import (
+	"embed"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/job"
+
+	testlog "knative.dev/reconciler-test/pkg/logging"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Example_min() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_full() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	opts := []manifest.CfgFn{
+		job.WithLabels(map[string]string{
+			"color": "green",
+		}),
+		job.WithAnnotations(map[string]interface{}{
+			"app.kubernetes.io/name": "app",
+		}),
+		job.WithRestartPolicy(v1.RestartPolicyNever),
+		job.WithImagePullPolicy(v1.PullNever),
+		job.WithBackoffLimit(20),
+		job.WithEnvs(map[string]string{
+			"VAR": "VAL",
+		}),
+		job.WithTTLSecondsAfterFinished(30),
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	//   annotations:
+	//     app.kubernetes.io/name: "app"
+	//   labels:
+	//     color: green
+	// spec:
+	//   backoffLimit: 20
+	//   ttlSecondsAfterFinished: 30
+	//   template:
+	//     spec:
+	//       restartPolicy: Never
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+	//         env:
+	//         - name: "VAR"
+	//           value: "VAL"
+	//         imagePullPolicy: Never
+}
+
+func Example_WithEnvs() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithEnvs(map[string]string{
+		"VAR1": "VALUE1",
+		"VAR2": "VALUE2",
+	})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+	//         env:
+	//         - name: "VAR1"
+	//           value: "VALUE1"
+	//         - name: "VAR2"
+	//           value: "VALUE2"
+}
+
+func Example_WithAnnotations() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithAnnotations(map[string]interface{}{"app.kubernetes.io/name": "app1"})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	//   annotations:
+	//     app.kubernetes.io/name: "app1"
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_WithLabels() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithLabels(map[string]string{
+		"color":   "blue",
+		"version": "3",
+	})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	//   labels:
+	//     color: blue
+	//     version: 3
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_WithImagePullPolicy() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithImagePullPolicy(v1.PullAlways)(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+	//         imagePullPolicy: Always
+}
+
+func Example_WithRestartPolicy() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithRestartPolicy(v1.RestartPolicyAlways)(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     spec:
+	//       restartPolicy: Always
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_WithBackoffLimit() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithBackoffLimit(165)(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   backoffLimit: 165
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}
+
+func Example_WithTTLSecondsAfterFinished() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithTTLSecondsAfterFinished(165)(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   ttlSecondsAfterFinished: 165
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+}

--- a/pkg/resources/job/options.go
+++ b/pkg/resources/job/options.go
@@ -45,6 +45,22 @@ func WithLabels(labels map[string]string) manifest.CfgFn {
 	}
 }
 
+func WithPodAnnotations(annotations map[string]interface{}) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if annotations != nil {
+			cfg["podannotations"] = annotations
+		}
+	}
+}
+
+func WithPodLabels(labels map[string]string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if labels != nil {
+			cfg["podlabels"] = labels
+		}
+	}
+}
+
 func WithImagePullPolicy(ipp corev1.PullPolicy) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["imagePullPolicy"] = ipp

--- a/pkg/resources/job/options.go
+++ b/pkg/resources/job/options.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package job
+
+import "knative.dev/reconciler-test/pkg/manifest"
+
+func WithImage(image string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["image"] = image
+	}
+}
+
+func WithEnvs(envs map[string]string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if envs != nil {
+			cfg["envs"] = envs
+		}
+	}
+}
+
+func WithAnnotations(annotations map[string]interface{}) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if annotations != nil {
+			cfg["annotations"] = annotations
+		}
+	}
+}
+
+func WithImagePullPolicy(ipp string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["imagePullPolicy"] = ipp
+	}
+}
+
+func WithRestartPolicy(restartPolicy string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["restartPolicy"] = restartPolicy
+	}
+}

--- a/pkg/resources/job/options.go
+++ b/pkg/resources/job/options.go
@@ -21,12 +21,6 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
-func WithImage(image string) manifest.CfgFn {
-	return func(cfg map[string]interface{}) {
-		cfg["image"] = image
-	}
-}
-
 func WithEnvs(envs map[string]string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		if envs != nil {
@@ -39,6 +33,14 @@ func WithAnnotations(annotations map[string]interface{}) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		if annotations != nil {
 			cfg["annotations"] = annotations
+		}
+	}
+}
+
+func WithLabels(labels map[string]string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if labels != nil {
+			cfg["labels"] = labels
 		}
 	}
 }
@@ -58,5 +60,11 @@ func WithRestartPolicy(restartPolicy corev1.RestartPolicy) manifest.CfgFn {
 func WithBackoffLimit(backoffLimit int) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["backoffLimit"] = backoffLimit
+	}
+}
+
+func WithTTLSecondsAfterFinished(ttlSecondsAfterFinished int) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["ttlSecondsAfterFinished"] = ttlSecondsAfterFinished
 	}
 }

--- a/pkg/resources/job/options.go
+++ b/pkg/resources/job/options.go
@@ -16,7 +16,10 @@
 
 package job
 
-import "knative.dev/reconciler-test/pkg/manifest"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
 
 func WithImage(image string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
@@ -40,13 +43,13 @@ func WithAnnotations(annotations map[string]interface{}) manifest.CfgFn {
 	}
 }
 
-func WithImagePullPolicy(ipp string) manifest.CfgFn {
+func WithImagePullPolicy(ipp corev1.PullPolicy) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["imagePullPolicy"] = ipp
 	}
 }
 
-func WithRestartPolicy(restartPolicy string) manifest.CfgFn {
+func WithRestartPolicy(restartPolicy corev1.RestartPolicy) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["restartPolicy"] = restartPolicy
 	}

--- a/pkg/resources/job/options.go
+++ b/pkg/resources/job/options.go
@@ -51,3 +51,9 @@ func WithRestartPolicy(restartPolicy string) manifest.CfgFn {
 		cfg["restartPolicy"] = restartPolicy
 	}
 }
+
+func WithBackoffLimit(backoffLimit int) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["backoffLimit"] = backoffLimit
+	}
+}


### PR DESCRIPTION
# Changes

- :gift: Add helpers to create & interact with batchv1.Job resources

This PR is influenced by knative/eventing, and how they create resources in their tests (e.g. [test/rekt/resources/broker/broker.go](https://github.com/knative/eventing/blob/main/test/rekt/resources/broker/broker.go)). In future other helpers for k8s native resources could be added and the content from `reconciler-test/pkg/k8s/` could be migrated.

/kind enhancement

