### PR TITLE
Migrate from `resources/svc` to `pkg/resources/service` internally

### DIFF
--- a/pkg/eventshub/prober.go
+++ b/pkg/eventshub/prober.go
@@ -35,7 +35,7 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/resources/svc"
+	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
 func NewProber() *EventProber {
@@ -321,7 +321,7 @@ func (p *EventProber) SenderEventsFromURI(uri string) {
 // env.Namespace(), based on context from the StepFn.
 func (p *EventProber) SenderEventsFromSVC(svcName, path string) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		u, err := svc.Address(ctx, svcName)
+		u, err := service.Address(ctx, svcName)
 		if err != nil {
 			t.Error(err)
 		}
@@ -372,7 +372,7 @@ func (p *EventProber) SenderMinEvents(count int) {
 
 // AsKReference returns the short-named component as a KReference.
 func (p *EventProber) AsKReference(prefix string) *duckv1.KReference {
-	return svc.AsKReference(p.getNameFromPrefix(prefix))
+	return service.AsKReference(p.getNameFromPrefix(prefix))
 }
 
 // AssertSentAll tests that `fromPrefix` sent all known events known to the prober.

--- a/test/example/recorder_feature.go
+++ b/test/example/recorder_feature.go
@@ -23,7 +23,7 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/resources/svc"
+	"knative.dev/reconciler-test/pkg/resources/service"
 
 	// Dot import the eventshub asserts and sdk-go test packages to include all the assert utilities
 	. "github.com/cloudevents/sdk-go/v2/test"
@@ -39,7 +39,7 @@ func RecorderFeature() *feature.Feature {
 	event := FullEvent()
 
 	f.Setup("install recorder", eventshub.Install(to, eventshub.StartReceiver))
-	f.Setup("recorder is addressable", k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second))
+	f.Setup("recorder is addressable", k8s.IsAddressable(service.GVR(), to, time.Second, 30*time.Second))
 
 	f.Requirement("install sender", eventshub.Install(from, eventshub.StartSender(to), eventshub.InputEvent(event)))
 
@@ -58,7 +58,7 @@ func RecorderFeatureYAML() *feature.Feature {
 	from := feature.MakeRandomK8sName("sender")
 
 	f.Setup("install recorder", eventshub.Install(to, eventshub.StartReceiver))
-	f.Setup("recorder is addressable", k8s.IsAddressable(svc.GVR(), to, time.Second, 30*time.Second))
+	f.Setup("recorder is addressable", k8s.IsAddressable(service.GVR(), to, time.Second, 30*time.Second))
 
 	f.Requirement("install sender with yaml events", eventshub.Install(from,
 		eventshub.StartSender(to),


### PR DESCRIPTION
Follow up on #457 to use `pkg/resources/service` internally

# Changes

- :broom: Migrate from `resources/svc` to `pkg/resources/service` internally