### PR TITLE
Add file-based image resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,3 +513,20 @@ go test -v -count=1 -tags=e2e ./test/... --feature=Noop
 
 If a private registry is to be used with authentication, a Secret needs to be created in the `default` namespace called `kn-test-image-pull-secret` with the credentials.
 The testing framework will copy this secret into any new namespaces created and will update the default ServiceAccount's imagePullSecret.
+
+### Using pre-built images
+
+By default, the framework builds images using `ko`, if test images are already built you can provide
+a file that maps Go main packages to your images:
+
+```yaml
+# images.yaml
+knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub
+knative.dev/reconciler-test/cmd/eventshub2: quay.io/myregistry/eventshub2
+```
+
+and then, reference the file in the `go test` command invocation:
+
+```
+go test -v -count=1 -tags=e2e ./test/... --images.producer.file=images.yaml
+```

--- a/pkg/environment/flags.go
+++ b/pkg/environment/flags.go
@@ -29,6 +29,8 @@ var (
 	s = new(feature.States)
 	l = new(feature.Levels)
 	f = new(string)
+
+	ipFilePath = new(string)
 )
 
 // InitFlags registers the requirement and state filter flags supported by the
@@ -54,6 +56,8 @@ func InitFlags(fs *flag.FlagSet) {
 
 	// Feature
 	fs.StringVar(f, "feature", "", "run only Features matching `regexp`")
+
+	fs.StringVar(ipFilePath, "images.producer.file", "", "file path for file-based image producer")
 }
 
 type stateValue struct {

--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -28,9 +28,13 @@ import (
 )
 
 var (
-	// CurrentImageProducer is the function that will be used to produce the
-	// container images. By default, it is ko.Publish, but can be overridden.
-	CurrentImageProducer = ImageProducer(ko.Publish)
+	// defaultImageProducer is the function that will be used to produce the
+	// container images by default.
+	//
+	// To use a different image producer pass a different ImageProducer
+	// when creating an Environment through GlobalEnvironment
+	// see WithImageProducer.
+	defaultImageProducer = ImageProducer(ko.Publish)
 
 	// produceImagesLock is used to ensure that ProduceImages is only called
 	// once at the time.
@@ -42,6 +46,8 @@ var (
 const parallelQueueSize = 1_000
 
 // ImageProducer is a function that will be used to produce the container images.
+//
+// pack is a Go main package reference like `knative.dev/reconciler-test/cmd/eventshub`.
 type ImageProducer func(ctx context.Context, pack string) (string, error)
 
 // RegisterPackage registers an interest in producing an image based on the
@@ -80,12 +86,15 @@ func ProduceImages(ctx context.Context) (map[string]string, error) {
 	rk := registeredPackagesKey{}
 	ik := imageStoreKey{}
 	store := ik.get(ctx)
+
+	ip := GetImageProducer(ctx)
+
 	for _, pack := range rk.packages(ctx) {
 		koPack := fmt.Sprintf("ko://%s", pack)
 		if store.refs[koPack] != "" {
 			continue
 		}
-		image, err := CurrentImageProducer(ctx, pack)
+		image, err := ip(ctx, pack)
 		if err != nil {
 			return nil, err
 		}
@@ -169,4 +178,30 @@ func (is imageStore) copyRefs() map[string]string {
 		refs[k] = v
 	}
 	return refs
+}
+
+// imageProducerKey is the key for the ImageProducer context value.
+type imageProducerKey struct{}
+
+// WithImageProducer allows using a different ImageProducer
+// when creating an Environment through GlobalEnvironment.
+// Example usage:
+// GlobalEnvironment.Environment(WithImageProducer(file.ImageProducer("images.yaml")))
+func WithImageProducer(producer ImageProducer) EnvOpts {
+	return func(ctx context.Context, env Environment) (context.Context, error) {
+		return withImageProducer(ctx, producer), nil
+	}
+}
+
+func withImageProducer(ctx context.Context, producer ImageProducer) context.Context {
+	return context.WithValue(ctx, imageProducerKey{}, producer)
+}
+
+// GetImageProducer extracts an ImageProducer from the given context.
+func GetImageProducer(ctx context.Context) ImageProducer {
+	p := ctx.Value(imageProducerKey{})
+	if p == nil {
+		return defaultImageProducer
+	}
+	return p.(ImageProducer)
 }

--- a/pkg/environment/images_test.go
+++ b/pkg/environment/images_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"knative.dev/reconciler-test/pkg/images/file"
 )
 
 func TestProduceImages(t *testing.T) {
@@ -54,4 +56,37 @@ func TestProduceImages(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestWithImageProducer(t *testing.T) {
+
+	ctx := context.Background()
+
+	ctx, err := WithImageProducer(file.ImageProducer("testdata/images.yaml"))(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ip := GetImageProducer(ctx)
+
+	tt := []struct {
+		key   string
+		value string
+	}{
+		{
+			key:   "knative.dev/reconciler-test/cmd/eventshub",
+			value: "quay.io/myregistry/eventshub",
+		},
+	}
+
+	for _, tc := range tt {
+		got, err := ip(ctx, tc.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != tc.value {
+			t.Errorf("expected value %s, got %s", tc.value, got)
+		}
+	}
 }

--- a/pkg/environment/standard.go
+++ b/pkg/environment/standard.go
@@ -21,6 +21,8 @@ import (
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+
+	"knative.dev/reconciler-test/pkg/images/file"
 	testlog "knative.dev/reconciler-test/pkg/logging"
 )
 
@@ -61,6 +63,10 @@ func NewStandardGlobalEnvironment(opts ...ConfigurationOption) GlobalEnvironment
 	// framework as well as any additional flags included in the integration.
 	if err := config.Flags.Parse(ctx); err != nil {
 		logging.FromContext(ctx).Fatal(err)
+	}
+
+	if ipFilePath != nil && *ipFilePath != "" {
+		ctx = withImageProducer(ctx, file.ImageProducer(*ipFilePath))
 	}
 
 	// EnableInjectionOrDie will enable client injection, this is used by the

--- a/pkg/environment/testdata/images.yaml
+++ b/pkg/environment/testdata/images.yaml
@@ -1,0 +1,3 @@
+# Comment
+
+knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub

--- a/pkg/images/file/file.go
+++ b/pkg/images/file/file.go
@@ -33,7 +33,7 @@ import (
 // knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub
 // # ... other images ...
 func ImageProducer(filepath string) func(ctx context.Context, pack string) (string, error) {
-	images := make(map[string]string, 2 /* */)
+	images := make(map[string]string, 2)
 
 	bytes, err := os.ReadFile(filepath)
 	if err != nil {

--- a/pkg/images/file/file.go
+++ b/pkg/images/file/file.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ImageProducer is a file-based image producer.
+// The expected file format is a YAML file like the following:
+// <go-package-ref>: <image-ref>
+//
+// For example:
+//
+// knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub
+// # ... other images ...
+func ImageProducer(filepath string) func(ctx context.Context, pack string) (string, error) {
+	images := make(map[string]string, 2 /* */)
+
+	bytes, err := os.ReadFile(filepath)
+	if err != nil {
+		panic("failed to read file " + filepath + ": " + err.Error())
+	}
+
+	if err := yaml.Unmarshal(bytes, images); err != nil {
+		panic("failed to unmarshal images file: " + err.Error() + "\nContent:\n" + string(bytes))
+	}
+
+	return func(ctx context.Context, pack string) (string, error) {
+		im, ok := images[pack]
+		if !ok {
+			return "", fmt.Errorf("image for package %s not found in %+v", pack, images)
+		}
+		return im, nil
+	}
+}

--- a/pkg/images/file/file_test.go
+++ b/pkg/images/file/file_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"context"
+	"testing"
+)
+
+func TestImageProducer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	producer := ImageProducer("testdata/images.yaml")
+
+	tt := []struct {
+		key   string
+		value string
+	}{
+		{
+			key:   "knative.dev/reconciler-test/cmd/eventshub",
+			value: "quay.io/myregistry/eventshub",
+		},
+		{
+			key:   "knative.dev/reconciler-test/cmd/eventshub2",
+			value: "quay.io/myregistry/eventshub",
+		},
+	}
+
+	for _, tc := range tt {
+		got, err := producer(ctx, tc.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != tc.value {
+			t.Errorf("expected value %s, got %s", tc.value, got)
+		}
+	}
+}

--- a/pkg/images/file/file_test.go
+++ b/pkg/images/file/file_test.go
@@ -28,8 +28,9 @@ func TestImageProducer(t *testing.T) {
 	producer := ImageProducer("testdata/images.yaml")
 
 	tt := []struct {
-		key   string
-		value string
+		key     string
+		value   string
+		wantErr bool
 	}{
 		{
 			key:   "knative.dev/reconciler-test/cmd/eventshub",
@@ -37,17 +38,21 @@ func TestImageProducer(t *testing.T) {
 		},
 		{
 			key:   "knative.dev/reconciler-test/cmd/eventshub2",
-			value: "quay.io/myregistry/eventshub",
+			value: "quay.io/myregistry/eventshub2",
+		},
+		{
+			key:     "knative.dev/reconciler-test/cmd/eventshub3",
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range tt {
 		got, err := producer(ctx, tc.key)
-		if err != nil {
-			t.Fatal(err)
+		if tc.wantErr != (err != nil) {
+			t.Fatal("want error", tc.wantErr, "error", err)
 		}
 
-		if got != tc.value {
+		if !tc.wantErr && got != tc.value {
 			t.Errorf("expected value %s, got %s", tc.value, got)
 		}
 	}

--- a/pkg/images/file/testdata/images.yaml
+++ b/pkg/images/file/testdata/images.yaml
@@ -1,0 +1,4 @@
+# Comment
+
+knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub
+knative.dev/reconciler-test/cmd/eventshub2: quay.io/myregistry/eventshub

--- a/pkg/images/file/testdata/images.yaml
+++ b/pkg/images/file/testdata/images.yaml
@@ -1,4 +1,4 @@
 # Comment
 
 knative.dev/reconciler-test/cmd/eventshub: quay.io/myregistry/eventshub
-knative.dev/reconciler-test/cmd/eventshub2: quay.io/myregistry/eventshub
+knative.dev/reconciler-test/cmd/eventshub2: quay.io/myregistry/eventshub2


### PR DESCRIPTION
Downstream we build images before running the tests and we don't use `ko`, so a file-based image resolver helps us referencing images differently.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>