### PR TITLE
Fix deployment resource image setting

### DIFF
--- a/pkg/resources/deployment/deployment.go
+++ b/pkg/resources/deployment/deployment.go
@@ -33,6 +33,7 @@ var yaml embed.FS
 func Install(name string, image string, options ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{
 		"name":      name,
+		"image":     image,
 		"selectors": map[string]string{"app": name}, // default
 	}
 


### PR DESCRIPTION
# Changes

- :bug: Set the image name in the deployment resources `Install`

/kind bug