### PR TITLE
[WIP] Allow verify service readiness when istio is installed 

### DIFF
--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -24,6 +24,7 @@ import (
 
 	"knative.dev/pkg/logging"
 
+	"knative.dev/reconciler-test/pkg/images"
 	"knative.dev/reconciler-test/pkg/images/ko"
 )
 
@@ -199,9 +200,18 @@ func withImageProducer(ctx context.Context, producer ImageProducer) context.Cont
 
 // GetImageProducer extracts an ImageProducer from the given context.
 func GetImageProducer(ctx context.Context) ImageProducer {
+	if images.GetSkipPublishImage(ctx) {
+		return identityImageProducer()
+	}
 	p := ctx.Value(imageProducerKey{})
 	if p == nil {
 		return defaultImageProducer
 	}
 	return p.(ImageProducer)
+}
+
+func identityImageProducer() ImageProducer {
+	return func(ctx context.Context, pack string) (string, error) {
+		return pack, nil
+	}
 }

--- a/pkg/environment/timings.go
+++ b/pkg/environment/timings.go
@@ -53,3 +53,28 @@ func PollTimingsFromContext(ctx context.Context) (time.Duration, time.Duration) 
 	}
 	return DefaultPollInterval, DefaultPollTimeout
 }
+
+// PollTimings will find the correct timings based on priority:
+// - passed timing slice [interval, timeout].
+// - values from from context.
+// - defaults.
+func PollTimings(ctx context.Context, timings []time.Duration) (time.Duration /*interval*/, time.Duration /*timeout*/) {
+	// Use the passed timing first, but it could be nil or a strange length.
+	if len(timings) >= 2 {
+		return timings[0], timings[1]
+	}
+
+	var interval *time.Duration
+
+	// Use the passed timings if only interval is provided.
+	if len(timings) == 1 {
+		interval = &timings[0]
+	}
+
+	di, timeout := PollTimingsFromContext(ctx)
+	if interval == nil {
+		interval = &di
+	}
+
+	return *interval, timeout
+}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/pod"
 )
 
 //go:embed *.yaml
@@ -94,7 +95,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		if err != nil {
 			log.Fatal(err)
 		}
-		k8s.WaitForPodRunningOrFail(ctx, t, name)
+		pod.IsRunning(name)(ctx, t)
 		k8s.WaitForReadyOrDoneOrFail(ctx, t, podref)
 
 		// If the eventhubs starts an event receiver, we need to wait for the service endpoint to be synced

--- a/pkg/images/register.go
+++ b/pkg/images/register.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+)
+
+type skipPublishImageKey struct{}
+
+func WithSkipPublishImage(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipPublishImageKey{}, true)
+}
+
+func GetSkipPublishImage(ctx context.Context) bool {
+	v := ctx.Value(skipPublishImageKey{})
+	if v == nil {
+		return false
+	}
+	return v.(bool)
+}

--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -17,194 +17,41 @@ limitations under the License.
 package k8s
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"time"
-
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/logging"
-	"knative.dev/reconciler-test/pkg/environment"
-	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/resources/job"
 )
 
-// WaitUntilJobDone waits until a job has finished.
-// Timing is optional but if provided is [interval, timeout].
-func WaitUntilJobDone(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
-	return WaitForJobCondition(ctx, t, name, IsJobComplete, timing...)
-}
-
-// WaitUntilJobSucceeded waits until a job has succeeded.
-// Timing is optional but if provided is [interval, timeout].
-func WaitUntilJobSucceeded(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
-	return WaitForJobCondition(ctx, t, name, IsJobSucceeded, timing...)
-}
-
-// WaitUntilJobFailed waits until a job has failed.
-// Timing is optional but if provided is [interval, timeout].
-func WaitUntilJobFailed(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
-	return WaitForJobCondition(ctx, t, name, IsJobFailed, timing...)
-}
-
-func WaitForJobCondition(ctx context.Context, t feature.T, name string, isConditionFunc func(job *batchv1.Job) bool, timing ...time.Duration) error {
-	interval, timeout := PollTimings(ctx, timing)
-	namespace := environment.FromContext(ctx).Namespace()
-	kube := kubeclient.Get(ctx)
-	jobs := kube.BatchV1().Jobs(namespace)
-
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		job, err := jobs.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				t.Logf("%s/%s job %+v", namespace, name, err)
-				// keep polling
-				return false, nil
-			}
-			return false, err
-		}
-
-		conditionIsTrue := isConditionFunc(job)
-		if !conditionIsTrue {
-			status, err := json.Marshal(job.Status)
-			if err != nil {
-				return false, err
-			}
-			t.Logf("%s/%s job status %s", namespace, name, status)
-		}
-		return conditionIsTrue, nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// WaitForJobTerminationMessage waits for a job to end and then collects the termination message.
-// Timing is optional but if provided is [interval, timeout].
-func WaitForJobTerminationMessage(ctx context.Context, t feature.T, name string, timing ...time.Duration) (string, error) {
-	interval, timeout := PollTimings(ctx, timing)
-	namespace := environment.FromContext(ctx).Namespace()
-
-	// poll until the pod is terminated.
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		pod, err := GetJobPodByJobName(ctx, name)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				t.Logf("%s/%s job termination %+v", namespace, name, err)
-				// keep polling
-				return false, nil
-			}
-			return false, err
-		}
-		if pod != nil {
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.State.Terminated != nil {
-					return true, nil
-				}
-			}
-		}
-		return false, nil
-	})
-
-	if err != nil {
-		return "", err
-	}
-	pod, err := GetJobPodByJobName(ctx, name)
-	if err != nil {
-		return "", err
-	}
-	return GetFirstTerminationMessage(pod), nil
-}
-
-func IsJobComplete(job *batchv1.Job) bool {
-	for _, c := range job.Status.Conditions {
-		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func IsJobSucceeded(job *batchv1.Job) bool {
-	return !IsJobFailed(job)
-}
-
-func IsJobFailed(job *batchv1.Job) bool {
-	for _, c := range job.Status.Conditions {
-		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func JobFailedMessage(job *batchv1.Job) string {
-	for _, c := range job.Status.Conditions {
-		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
-			return fmt.Sprintf("[%s] %s", c.Reason, c.Message)
-		}
-	}
-	return ""
-}
-
-// GetJobPod will find the Pod that belongs to the resource that created it.
-// Uses label ""controller-uid  as the label selector. So, your job should
-// tag the job with that label as the UID of the resource that's needing it.
-// For example, if you create a storage object that requires us to create
-// a notification for it, the controller should set the label on the
-// Job responsible for creating the Notification for it with the label
-// "controller-uid" set to the uid of the storage CR.
-func GetJobPod(ctx context.Context, kubeClientset kubernetes.Interface, namespace, uid, operation string) (*corev1.Pod, error) {
-	logger := logging.FromContext(ctx)
-	logger.Infof("Looking for Pod with UID: %q action: %q", uid, operation)
-	matchLabels := map[string]string{
-		"resource-uid": uid,
-		"action":       operation,
-	}
-	labelSelector := &metav1.LabelSelector{
-		MatchLabels: matchLabels,
-	}
-	pods, err := kubeClientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
-	if err != nil {
-		return nil, err
-	}
-	for _, pod := range pods.Items {
-		logger.Infof("Found pod: %q", pod.Name)
-		return &pod, nil
-	}
-	return nil, fmt.Errorf("Pod not found")
-}
-
-// GetJobPodByJobName will find the Pods that belong to that job. Each pod
-// for a given job will have label called: "job-name" set to the job that
-// it belongs to, so just filter by that.
-func GetJobPodByJobName(ctx context.Context, jobName string) (*corev1.Pod, error) {
-	logger := logging.FromContext(ctx)
-	namespace := environment.FromContext(ctx).Namespace()
-	kube := kubeclient.Get(ctx)
-	logger.Infof("Looking for Pod with jobname: %q", jobName)
-	matchLabels := map[string]string{
-		"job-name": jobName,
-	}
-	labelSelector := &metav1.LabelSelector{
-		MatchLabels: matchLabels,
-	}
-	pods, err := kube.CoreV1().Pods(namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
-	if err != nil {
-		return nil, err
-	}
-	for _, pod := range pods.Items {
-		logger.Infof("Found pod: %q", pod.Name)
-		return &pod, nil
-	}
-	return nil, fmt.Errorf("Pod not found")
-}
+var (
+	// WaitUntilJobDone
+	// Deprecated
+	WaitUntilJobDone = job.WaitUntilJobDone
+	// WaitUntilJobSucceeded
+	// Deprecated, use corresponding function in job package
+	WaitUntilJobSucceeded = job.WaitUntilJobSucceeded
+	// WaitUntilJobFailed
+	// Deprecated, use corresponding function in job package
+	WaitUntilJobFailed = job.WaitUntilJobFailed
+	// WaitForJobCondition
+	// Deprecated, use corresponding function in job package
+	WaitForJobCondition = job.WaitForJobCondition
+	// WaitForJobTerminationMessage
+	// Deprecated, use corresponding function in job package
+	WaitForJobTerminationMessage = job.WaitForJobTerminationMessage
+	// IsJobComplete
+	// Deprecated, use corresponding function in job package
+	IsJobComplete = job.IsCompleteJob
+	// IsJobSucceeded
+	// Deprecated, use corresponding function in job package
+	IsJobSucceeded = job.IsSucceededJob
+	// IsJobFailed
+	// Deprecated, use corresponding function in job package
+	IsJobFailed = job.IsFailedJob
+	// JobFailedMessage
+	// Deprecated, use corresponding function in job package
+	JobFailedMessage = job.FailedMessage
+	// GetJobPod
+	// Deprecated
+	GetJobPod = job.GetJobPod
+	// GetJobPodByJobName
+	// Deprecated, use corresponding function in job package
+	GetJobPodByJobName = job.GetJobPodByJobName
+)

--- a/pkg/k8s/logs.go
+++ b/pkg/k8s/logs.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// Deprecated use pod.Logs
 func LogsFor(client kubernetes.Interface, namespace, name string, gvr schema.GroupVersionResource) (string, error) {
 	// Get all pods in this namespace.
 	pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})

--- a/pkg/k8s/pod.go
+++ b/pkg/k8s/pod.go
@@ -21,12 +21,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/pkg/kmeta"
-	pkgsecurity "knative.dev/pkg/test/security"
+
+	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/pod"
 )
 
 func GetFirstTerminationMessage(pod *corev1.Pod) string {
@@ -55,58 +53,9 @@ func GetOperationsResult(ctx context.Context, pod *corev1.Pod, result interface{
 	return nil
 }
 
-// PodReference will return a reference to the pod.
-func PodReference(namespace string, name string) (corev1.ObjectReference, error) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: namespace,
-		},
-	}
-	scheme := runtime.NewScheme()
-	err := corev1.SchemeBuilder.AddToScheme(scheme)
-	if err != nil {
-		return corev1.ObjectReference{}, errors.WithStack(err)
-	}
-	kinds, _, err := scheme.ObjectKinds(pod)
-	if err != nil {
-		return corev1.ObjectReference{}, errors.WithStack(err)
-	}
-	if !(len(kinds) > 0) {
-		return corev1.ObjectReference{}, errors.New("want len(kinds) > 0")
-	}
-	kind := kinds[0]
-	pod.APIVersion, pod.Kind = kind.ToAPIVersionAndKind()
-	return kmeta.ObjectReference(pod), nil
-}
-
-func WithDefaultPodSecurityContext(cfg map[string]interface{}) {
-	if _, set := cfg["podSecurityContext"]; !set {
-		cfg["podSecurityContext"] = map[string]interface{}{}
-	}
-	podSecurityContext := cfg["podSecurityContext"].(map[string]interface{})
-	podSecurityContext["runAsNonRoot"] = pkgsecurity.DefaultPodSecurityContext.RunAsNonRoot
-	podSecurityContext["seccompProfile"] = map[string]interface{}{}
-	seccompProfile := podSecurityContext["seccompProfile"].(map[string]interface{})
-	seccompProfile["type"] = pkgsecurity.DefaultPodSecurityContext.SeccompProfile.Type
-
-	if _, set := cfg["containerSecurityContext"]; !set {
-		cfg["containerSecurityContext"] = map[string]interface{}{}
-	}
-	containerSecurityContext := cfg["containerSecurityContext"].(map[string]interface{})
-	containerSecurityContext["allowPrivilegeEscalation"] =
-		pkgsecurity.DefaultContainerSecurityContext.AllowPrivilegeEscalation
-	containerSecurityContext["capabilities"] = map[string]interface{}{}
-	capabilities := containerSecurityContext["capabilities"].(map[string]interface{})
-	if len(pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop) != 0 {
-		capabilities["drop"] = []string{}
-		for _, drop := range pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop {
-			capabilities["drop"] = append(capabilities["drop"].([]string), string(drop))
-		}
-	}
-	if len(pkgsecurity.DefaultContainerSecurityContext.Capabilities.Add) != 0 {
-		capabilities["add"] = []string{}
-		for _, drop := range pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop {
-			capabilities["add"] = append(capabilities["add"].([]string), string(drop))
-		}
-	}
-}
+var (
+	// Deprecated, use manifest.WithDefaultPodSecurityContext
+	WithDefaultPodSecurityContext = manifest.WithDefaultPodSecurityContext
+	// Deprecated, use pod.Reference
+	PodReference = pod.Reference
+)

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -38,6 +38,7 @@ import (
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/images"
 	"knative.dev/reconciler-test/pkg/resources/job"
 	"knative.dev/reconciler-test/pkg/resources/pod"
 )
@@ -308,6 +309,8 @@ func WaitForServiceReady(ctx context.Context, t feature.T, name string, readines
 	curl += fmt.Sprintf("%s && %s", curl, maybeQuitIstio)
 
 	jobName := feature.MakeRandomK8sName(name + "-readiness-check")
+
+	ctx = images.WithSkipPublishImage(ctx)
 
 	err := job.InstallError(
 		ctx,

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -306,7 +306,7 @@ func WaitForServiceReady(ctx context.Context, t feature.T, name string, readines
 		"--trace-ascii %% --trace-time "+
 		"--retry 6 --retry-connrefused %s", sinkURI)
 	maybeQuitIstio := fmt.Sprintf("(curl -fsI -X POST http://localhost:15020/quitquitquit || echo no-istio)")
-	curl += fmt.Sprintf("%s && %s", curl, maybeQuitIstio)
+	curl = fmt.Sprintf("%s && %s", curl, maybeQuitIstio)
 
 	jobName := feature.MakeRandomK8sName(name + "-readiness-check")
 

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -325,6 +325,8 @@ func WaitForServiceReady(ctx context.Context, t feature.T, name string, readines
 	curl := fmt.Sprintf("curl --max-time 2 "+
 		"--trace-ascii %% --trace-time "+
 		"--retry 6 --retry-connrefused %s", sinkURI)
+	mayBeQuitIstio := fmt.Sprintf("(curl -fsI -X POST http://localhost:15020/quitquitquit || echo no-istio)")
+	curl += fmt.Sprintf("%s && %s", curl, mayBeQuitIstio)
 	var one int32 = 1
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: ns},

--- a/pkg/resources/job/job.go
+++ b/pkg/resources/job/job.go
@@ -214,7 +214,7 @@ func IsCompleteJob(job *batchv1.Job) bool {
 }
 
 func IsSucceededJob(job *batchv1.Job) bool {
-	return !IsFailedJob(job)
+	return IsCompleteJob(job) && !IsFailedJob(job)
 }
 
 func IsFailedJob(job *batchv1.Job) bool {

--- a/pkg/resources/job/job.go
+++ b/pkg/resources/job/job.go
@@ -19,18 +19,38 @@ package job
 import (
 	"context"
 	"embed"
+	"encoding/json"
+	"fmt"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/pod"
 )
 
 //go:embed *.yaml
 var yaml embed.FS
 
 func Install(name string, image string, options ...manifest.CfgFn) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := InstallError(ctx, t, name, image, options...); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func InstallError(ctx context.Context, t feature.T, name string, image string, options ...manifest.CfgFn) error {
 	cfg := map[string]interface{}{
 		"name":  name,
 		"image": image,
@@ -40,26 +60,46 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 		fn(cfg)
 	}
 
-	return func(ctx context.Context, t feature.T) {
-		if err := registerImage(ctx, image); err != nil {
-			t.Fatal(err)
-		}
+	if err := registerImage(ctx, image); err != nil {
+		return err
+	}
 
-		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
-			manifest.WithIstioPodAnnotations(cfg)
-		}
+	if ic := environment.GetIstioConfig(ctx); ic.Enabled {
+		manifest.WithIstioPodAnnotations(cfg)
+	}
 
-		manifest.PodSecurityCfgFn(ctx, t)(cfg)
+	manifest.PodSecurityCfgFn(ctx, t)(cfg)
 
-		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
-			t.Fatal(err)
-		}
+	if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WithArgs adds arguments to container
+func WithArgs(args []string) manifest.CfgFn {
+	return func(m map[string]interface{}) {
+		m["args"] = args
+	}
+}
+
+// WithCommand adds command to container
+func WithCommand(command []string) manifest.CfgFn {
+	return func(m map[string]interface{}) {
+		m["command"] = command
+	}
+}
+
+func WithCompletions(c int32) manifest.CfgFn {
+	return func(m map[string]interface{}) {
+		m["completions"] = c
 	}
 }
 
 func IsDone(name string, timing ...time.Duration) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if err := k8s.WaitUntilJobDone(ctx, t, name, timing...); err != nil {
+		if err := WaitUntilJobDone(ctx, t, name, timing...); err != nil {
 			t.Error("Job did not turn into done state", err)
 		}
 	}
@@ -67,7 +107,7 @@ func IsDone(name string, timing ...time.Duration) feature.StepFn {
 
 func IsSucceeded(name string, timing ...time.Duration) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if err := k8s.WaitUntilJobSucceeded(ctx, t, name, timing...); err != nil {
+		if err := WaitUntilJobSucceeded(ctx, t, name, timing...); err != nil {
 			t.Error("Job did not succeed", err)
 		}
 	}
@@ -75,10 +115,193 @@ func IsSucceeded(name string, timing ...time.Duration) feature.StepFn {
 
 func IsFailed(name string, timing ...time.Duration) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if err := k8s.WaitUntilJobFailed(ctx, t, name, timing...); err != nil {
+		if err := WaitUntilJobFailed(ctx, t, name, timing...); err != nil {
 			t.Error("Job did not fail", err)
 		}
 	}
+}
+
+// WaitUntilJobDone waits until a job has finished.
+// Timing is optional but if provided is [interval, timeout].
+func WaitUntilJobDone(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
+	return WaitForJobCondition(ctx, t, name, IsCompleteJob, timing...)
+}
+
+// WaitUntilJobSucceeded waits until a job has succeeded.
+// Timing is optional but if provided is [interval, timeout].
+func WaitUntilJobSucceeded(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
+	return WaitForJobCondition(ctx, t, name, IsSucceededJob, timing...)
+}
+
+// WaitUntilJobFailed waits until a job has failed.
+// Timing is optional but if provided is [interval, timeout].
+func WaitUntilJobFailed(ctx context.Context, t feature.T, name string, timing ...time.Duration) error {
+	return WaitForJobCondition(ctx, t, name, IsFailedJob, timing...)
+}
+
+func WaitForJobCondition(ctx context.Context, t feature.T, name string, isConditionFunc func(job *batchv1.Job) bool, timing ...time.Duration) error {
+	interval, timeout := environment.PollTimings(ctx, timing)
+	namespace := environment.FromContext(ctx).Namespace()
+	kube := kubeclient.Get(ctx)
+	jobs := kube.BatchV1().Jobs(namespace)
+	var last *batchv1.Job
+
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		job, err := jobs.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("%s/%s job %+v", namespace, name, err)
+				// keep polling
+				return false, nil
+			}
+			return false, err
+		}
+		last = job
+
+		conditionIsTrue := isConditionFunc(job)
+		if !conditionIsTrue {
+			status, err := json.Marshal(job.Status)
+			if err != nil {
+				return false, err
+			}
+			t.Logf("%s/%s job status %s", namespace, name, status)
+		}
+		return conditionIsTrue, nil
+	})
+	if err != nil {
+		p, err := GetJobPodByJobName(ctx, name)
+		if err != nil {
+			return err
+		}
+		logs, err := pod.Logs(ctx, p.GetName(), "job-container", namespace)
+		if err != nil {
+			return err
+		}
+		status, err := json.MarshalIndent(last.Status, "", "  ")
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("job condition failed, status: \n%s\n---\nlogs:\n%s", string(status), logs)
+	}
+
+	return nil
+}
+
+// WaitForJobTerminationMessage waits for a job to end and then collects the termination message.
+// Timing is optional but if provided is [interval, timeout].
+func WaitForJobTerminationMessage(ctx context.Context, t feature.T, name string, timing ...time.Duration) (string, error) {
+	waitF := func(job *batchv1.Job) bool {
+		return job.Status.Failed+job.Status.Succeeded > 0
+	}
+	if err := WaitForJobCondition(ctx, t, name, waitF, timing...); err != nil {
+		return "", err
+	}
+
+	pod, err := GetJobPodByJobName(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	return getFirstTerminationMessage(pod), nil
+}
+
+func IsCompleteJob(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func IsSucceededJob(job *batchv1.Job) bool {
+	return !IsFailedJob(job)
+}
+
+func IsFailedJob(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func FailedMessage(job *batchv1.Job) string {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return fmt.Sprintf("[%s] %s", c.Reason, c.Message)
+		}
+	}
+	return ""
+}
+
+// GetJobPod will find the Pod that belongs to the resource that created it.
+// Uses label ""controller-uid  as the label selector. So, your job should
+// tag the job with that label as the UID of the resource that's needing it.
+// For example, if you create a storage object that requires us to create
+// a notification for it, the controller should set the label on the
+// Job responsible for creating the Notification for it with the label
+// "controller-uid" set to the uid of the storage CR.
+// TODO what is the use case for this function here?
+// Deprecated, what is the use case here https://github.com/knative-sandbox/reconciler-test/issues/new?
+func GetJobPod(ctx context.Context, kubeClientset kubernetes.Interface, namespace, uid, operation string) (*corev1.Pod, error) {
+	logger := logging.FromContext(ctx)
+	logger.Infof("Looking for Pod with UID: %q action: %q", uid, operation)
+	matchLabels := map[string]string{
+		"resource-uid": uid,
+		"action":       operation,
+	}
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: matchLabels,
+	}
+	pods, err := kubeClientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods.Items {
+		logger.Infof("Found pod: %q", pod.Name)
+		return &pod, nil
+	}
+	return nil, fmt.Errorf("Pod not found")
+}
+
+// GetJobPodByJobName will find the Pods that belong to that job. Each pod
+// for a given job will have label called: "job-name" set to the job that
+// it belongs to, so just filter by that.
+// TODO what is the use case for this function here to require it to be public?
+// TODO this function is tied to this job package and how it works, so make it private since
+func GetJobPodByJobName(ctx context.Context, jobName string) (*corev1.Pod, error) {
+	logger := logging.FromContext(ctx)
+	namespace := environment.FromContext(ctx).Namespace()
+	kube := kubeclient.Get(ctx)
+	logger.Infof("Looking for Pod with jobname: %q", jobName)
+	matchLabels := map[string]string{
+		"job-name": jobName,
+	}
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: matchLabels,
+	}
+	pods, err := kube.CoreV1().Pods(namespace).
+		List(ctx, metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods.Items {
+		logger.Infof("Found pod: %q", pod.Name)
+		return &pod, nil
+	}
+	return nil, fmt.Errorf("Pod not found")
+}
+
+func getFirstTerminationMessage(pod *corev1.Pod) string {
+	if pod != nil {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+				return cs.State.Terminated.Message
+			}
+		}
+	}
+	return ""
 }
 
 func registerImage(ctx context.Context, image string) error {

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -22,6 +22,9 @@ spec:
   {{ if .ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
   {{ end }}
+  {{ if .completions }}
+  completions: {{ .completions }}
+  {{ end }}
   template:
     {{ if or .podannotations .podlabels }}
     metadata:
@@ -51,6 +54,18 @@ spec:
       containers:
       - name: job-container
         image: {{ .image }}
+        {{ if .command }}
+        command:
+        {{ range $cmd := .command }}
+        - {{ printf "%q" $cmd }}
+        {{ end }}
+        {{ end }}
+        {{ if .args }}
+        args:
+        {{ range $arg := .args }}
+        - {{ printf "%q" $arg }}
+        {{ end }}
+        {{ end }}
         {{ if .envs }}
         env:
         {{ range $key, $value := .envs }}

--- a/pkg/resources/job/job_test.go
+++ b/pkg/resources/job/job_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	v1 "k8s.io/api/core/v1"
+
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/job"
 
@@ -367,4 +368,41 @@ func Example_WithTTLSecondsAfterFinished() {
 	//       containers:
 	//       - name: job-container
 	//         image: baz
+}
+
+func Example_withCommandArgs() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	job.WithArgs([]string{"a", "b"})(cfg)
+	job.WithCommand([]string{"/bin/sh"})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: Job
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   template:
+	//     spec:
+	//       containers:
+	//       - name: job-container
+	//         image: baz
+	//         command:
+	//         - "/bin/sh"
+	//         args:
+	//         - "a"
+	//         - "b"
 }

--- a/pkg/resources/pod/pod.go
+++ b/pkg/resources/pod/pod.go
@@ -19,6 +19,18 @@ package pod
 import (
 	"context"
 	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/kmeta"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -54,8 +66,104 @@ func Install(name string, image string, opts ...manifest.CfgFn) feature.StepFn {
 	}
 }
 
+func IsRunning(name string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		ns := environment.FromContext(ctx).Namespace()
+		podClient := kubeclient.Get(ctx).CoreV1().Pods(ns)
+		p := podClient
+		interval, timeout := environment.PollTimings(ctx, nil)
+		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			p, err := p.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					t.Log("pod", "namespace", ns, "name", name, err)
+					// keep polling
+					return false, nil
+				}
+				return true, err
+			}
+			isRunning := podRunning(p)
+
+			if !isRunning {
+				t.Logf("Pod %s/%s is not running...", ns, name)
+			}
+
+			return isRunning, nil
+		})
+		if err != nil {
+			sb := strings.Builder{}
+			if p, err := podClient.Get(ctx, name, metav1.GetOptions{}); err != nil {
+				sb.WriteString(err.Error())
+				sb.WriteString("\n")
+			} else {
+				sb.WriteString("Pod: ")
+				podJson, _ := json.MarshalIndent(p, "", "  ")
+				sb.WriteString(string(podJson))
+				sb.WriteString("\n")
+				for _, c := range p.Spec.Containers {
+					if b, err := Logs(ctx, name, c.Name, environment.FromContext(ctx).Namespace()); err != nil {
+						sb.WriteString(err.Error())
+					} else {
+						sb.Write(b)
+					}
+					sb.WriteString("\n")
+				}
+			}
+			t.Fatalf("Failed while waiting for pod %s running: %+v\n%s\n", name, errors.WithStack(err), sb.String())
+		}
+	}
+}
+
 func registerImage(ctx context.Context, image string) error {
 	reg := environment.RegisterPackage(image)
 	_, err := reg(ctx, environment.FromContext(ctx))
 	return err
+}
+
+// Logs returns Pod logs for given Pod and Container in the namespace
+func Logs(ctx context.Context, podName, containerName, namespace string) ([]byte, error) {
+	podClient := kubeclient.Get(ctx).CoreV1().Pods(namespace)
+	podList, err := podClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range podList.Items {
+		// Pods are big, so avoid copying.
+		pod := &podList.Items[i]
+		if strings.Contains(pod.Name, podName) {
+			result := podClient.GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: containerName,
+			}).Do(ctx)
+			return result.Raw()
+		}
+	}
+	return nil, fmt.Errorf("could not find logs for %s/%s:%s", namespace, podName, containerName)
+}
+
+func Reference(namespace string, name string) (corev1.ObjectReference, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: namespace,
+		},
+	}
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	if err != nil {
+		return corev1.ObjectReference{}, errors.WithStack(err)
+	}
+	kinds, _, err := scheme.ObjectKinds(pod)
+	if err != nil {
+		return corev1.ObjectReference{}, errors.WithStack(err)
+	}
+	if !(len(kinds) > 0) {
+		return corev1.ObjectReference{}, errors.New("want len(kinds) > 0")
+	}
+	kind := kinds[0]
+	pod.APIVersion, pod.Kind = kind.ToAPIVersionAndKind()
+	return kmeta.ObjectReference(pod), nil
+}
+
+// podRunning will check the status conditions of the pod and return true if it's Running.
+func podRunning(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded
 }

--- a/test/example/echo_feature.go
+++ b/test/example/echo_feature.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/resources/job"
 	"knative.dev/reconciler-test/test/example/config/echo"
 )
 
@@ -37,7 +38,7 @@ func EchoFeature() *feature.Feature {
 	f.Setup("install echo", echo.Install(name, msg))
 
 	f.Requirement("echo job is finished", func(ctx context.Context, t feature.T) {
-		if err := k8s.WaitUntilJobDone(ctx, t, name); err != nil {
+		if err := job.WaitUntilJobDone(ctx, t, name); err != nil {
 			t.Errorf("failed to wait for job to finish, %s", err)
 		}
 	})
@@ -46,7 +47,7 @@ func EchoFeature() *feature.Feature {
 		Must("the echo pod must echo our message",
 			func(ctx context.Context, t feature.T) {
 				// The usage of WaitForJobTerminationMessage here explicitly sets the poll timings.
-				log, err := k8s.WaitForJobTerminationMessage(ctx, t, name, time.Second, 30*time.Second)
+				log, err := job.WaitForJobTerminationMessage(ctx, t, name, time.Second, 30*time.Second)
 				if err != nil {
 					t.Error("failed to get termination message from pod, ", err)
 				}


### PR DESCRIPTION
The WaitForServiceReady was deploying a job without using the job
package which means that the pod created out of the job is not
annotated with istio injection annotation.

In addition, jobs with istio need to quit their sidecar when
they ends so that the job can be considered "successful".

Unfortunately, moving it to use job created a bigger problem
caused by import cycles, since job was depending on k8s
package and k8s package would have depended on job package.
To solve that problem, I needed to restructure the package
structure so that k8s package dependes on lower level packages
like `job`, `pod`, etc.

I think the k8s package and functions should be all moved to
their respective resource package because it now contains
a lot of unrelated content and it isn't clear what is the
difference between `k8s` and packages under `resources/*`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>