### PR TITLE
Restart eventshub on failure

### DIFF
--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -27,7 +27,7 @@ metadata:
   {{ end }}
 spec:
   serviceAccountName: "{{ .namespace }}"
-  restartPolicy: "Never"
+  restartPolicy: "OnFailure"
   {{ if .podSecurityContext }}
   securityContext:
     runAsNonRoot: {{ .podSecurityContext.runAsNonRoot }}

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -75,7 +75,7 @@ func Example() {
 	//     app: eventshub-hubhub
 	// spec:
 	//   serviceAccountName: "example"
-	//   restartPolicy: "Never"
+	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
 	//       image: uri://a-real-container
@@ -151,7 +151,7 @@ func ExampleIstioAnnotation() {
 	//       sidecar.istio.io/rewriteAppHTTPProbers: "true"
 	// spec:
 	//   serviceAccountName: "example"
-	//   restartPolicy: "Never"
+	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
 	//       image: uri://a-real-container
@@ -221,7 +221,7 @@ func ExampleNoReadiness() {
 	//     app: eventshub-hubhub
 	// spec:
 	//   serviceAccountName: "example"
-	//   restartPolicy: "Never"
+	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
 	//       image: uri://a-real-container


### PR DESCRIPTION
When using eventshub on pods with istio sidecar injected, they terminate with failures since until the istio sidercar is ready network is not working so events will fail to get delivered to the configured destination.