### PR TITLE
Allow specifying parallel tests for parallelizable features

### DIFF
--- a/pkg/environment/interfaces.go
+++ b/pkg/environment/interfaces.go
@@ -45,8 +45,16 @@ type Environment interface {
 	// Test will execute the feature test using the given Context and T.
 	Test(ctx context.Context, t *testing.T, f *feature.Feature)
 
+	// ParallelTest will execute the feature test using the given Context and T in parallel with
+	// other parallel features.
+	ParallelTest(ctx context.Context, t *testing.T, f *feature.Feature)
+
 	// TestSet will execute the feature set using the given Context and T.
 	TestSet(ctx context.Context, t *testing.T, fs *feature.FeatureSet)
+
+	// ParallelTestSet will execute the feature set using the given Context and T with each feature
+	// running in parallel with other parallel features.
+	ParallelTestSet(ctx context.Context, t *testing.T, f *feature.FeatureSet)
 
 	// Namespace returns the namespace of this environment.
 	Namespace() string

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -104,7 +104,6 @@ func testTimingConstraints(t *testing.T, isParallel bool) {
 			env.ParallelTest(ctx, t, feat)
 		})
 	} else {
-
 		env.Test(ctx, t, feat)
 	}
 


### PR DESCRIPTION
The below pseudo-code will run `f1` and `f2` sequentially:
```
Environment.Test(ctx, t, f1)
Environment.Test(ctx, t, f2)
```
However, some features can be beneficial to run them in parallel
with other parallel features since most of our tests are waiting
for something to become ready.

This PR adds:
```
Environment.ParallelTest(ctx, t, f1)
Environment.ParallelTestSet(ctx, t, fs1)
```

to specify that a feature or a feature set can be run
in parallel.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allow specifying parallel tests for parallelizable features

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Allow specifying parallel tests for parallelizable features
```
