### PR TITLE
Allow using a prespecified namespace for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,16 @@ command line flag:
 go test -v -count=1 -tags=e2e ./test/... --istio.enabled=true
 ```
 
+### Using a specific namespace
+
+By default, reconciler-test uses auto-generated namespaces to run tests, to use a specific
+namespace, a flag, `environment.namespace` can be provided, and it will create
+the namespace if it doesn't exist.
+
+```shell
+go test -v -count=1 -tags=e2e ./test/... --environment.namespace=knative-tests
+```
+
 #### Using Private Registries
 
 If a private registry is to be used with authentication, a Secret needs to be created in the `default` namespace called `kn-test-image-pull-secret` with the credentials.

--- a/pkg/environment/flags.go
+++ b/pkg/environment/flags.go
@@ -30,6 +30,8 @@ var (
 	l = new(feature.Levels)
 	f = new(string)
 
+	testNamespace = new(string)
+
 	ipFilePath     = new(string)
 	teardownOnFail = new(bool)
 )
@@ -59,6 +61,7 @@ func InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(f, "feature", "", "run only Features matching `regexp`")
 
 	fs.StringVar(ipFilePath, "images.producer.file", "", "file path for file-based image producer")
+	fs.StringVar(testNamespace, "environment.namespace", "", "Test namespace")
 
 	fs.BoolVar(teardownOnFail, "teardown.on.fail", false, "Set this flag to do teardown even if test fails.")
 }

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -26,8 +26,23 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	"knative.dev/reconciler-test/pkg/milestone"
 )
+
+type namespaceKey struct{}
+
+func withNamespace(ctx context.Context, namespace string) context.Context {
+	return context.WithValue(ctx, namespaceKey{}, namespace)
+}
+
+func getNamespace(ctx context.Context) string {
+	ns := ctx.Value(namespaceKey{})
+	if ns == nil {
+		return ""
+	}
+	return ns.(string)
+}
 
 // CreateNamespaceIfNeeded creates a new namespace if it does not exist.
 func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {

--- a/pkg/environment/standard.go
+++ b/pkg/environment/standard.go
@@ -70,6 +70,10 @@ func NewStandardGlobalEnvironment(opts ...ConfigurationOption) GlobalEnvironment
 		ctx = withImageProducer(ctx, file.ImageProducer(*ipFilePath))
 	}
 
+	if testNamespace != nil && *testNamespace != "" {
+		ctx = withNamespace(ctx, *testNamespace)
+	}
+
 	// EnableInjectionOrDie will enable client injection, this is used by the
 	// testing framework for namespace management, and could be leveraged by
 	// features to pull Kubernetes clients or the test environment out of the


### PR DESCRIPTION
For testing istio with eventing, I'd like to specify a specific
namespace so that it can be pre configured with some istio-specific
configurations.
