### PR TITLE
Support cronjobs

### DIFF
--- a/pkg/environment/images.go
+++ b/pkg/environment/images.go
@@ -18,6 +18,7 @@ package environment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -95,6 +96,11 @@ func ProduceImages(ctx context.Context) (map[string]string, error) {
 			continue
 		}
 		image, err := ip(ctx, pack)
+		if errors.Is(err, ko.ErrKoPublishFailed) {
+			logging.FromContext(ctx).Warnw("Ko publish failed, using image directly", "error", err, "image", pack)
+			image = pack
+			err = nil
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resources/cronjob/cronjob.go
+++ b/pkg/resources/cronjob/cronjob.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cronjob
+
+import (
+	"context"
+	"embed"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Install(name string, image string, options ...manifest.CfgFn) feature.StepFn {
+	cfg := map[string]interface{}{
+		"name":  name,
+		"image": image,
+	}
+
+	defaultOptions := []manifest.CfgFn{
+		WithRestartPolicy(corev1.RestartPolicyOnFailure),
+	}
+
+	options = append(defaultOptions, options...)
+
+	for _, fn := range options {
+		fn(cfg)
+	}
+
+	return func(ctx context.Context, t feature.T) {
+		if err := registerImage(ctx, image); err != nil {
+			t.Fatal(err)
+		}
+
+		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
+			manifest.WithIstioPodAnnotations(cfg)
+		}
+
+		manifest.PodSecurityCfgFn(ctx, t)(cfg)
+
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func getJobNameFromCronJobName(ctx context.Context, t feature.T, name string) string {
+	var job *batchv1.Job
+	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": name,
+		},
+	})
+
+	interval, timeout := environment.PollTimingsFromContext(ctx)
+	err := wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+
+		jobs, err := kubeclient.Get(ctx).BatchV1().
+			Jobs(environment.FromContext(ctx).Namespace()).
+			List(ctx, metav1.ListOptions{
+				LabelSelector: selector.String(),
+			})
+		if err != nil {
+			t.Error(err)
+			return false, err
+		}
+
+		for _, j := range jobs.Items {
+			job = &j
+			return true, nil
+		}
+
+		t.Logf("No jobs found for selector %s", selector.String())
+
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("Failed to find a job matching selector %s", selector)
+		return ""
+	}
+
+	return job.Name
+}
+
+func AtLeastOneIsDone(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobDone(ctx, t, getJobNameFromCronJobName(ctx, t, name), timing...); err != nil {
+			t.Error("Job did not turn into done state", err)
+		}
+	}
+}
+
+func AtLeastOneIsSucceeded(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobSucceeded(ctx, t, getJobNameFromCronJobName(ctx, t, name), timing...); err != nil {
+			t.Error("Job did not succeed", err)
+		}
+	}
+}
+
+func AtLeastOneIsFailed(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		if err := k8s.WaitUntilJobFailed(ctx, t, getJobNameFromCronJobName(ctx, t, name), timing...); err != nil {
+			t.Error("Job did not fail", err)
+		}
+	}
+}
+
+func registerImage(ctx context.Context, image string) error {
+	reg := environment.RegisterPackage(image)
+	_, err := reg(ctx, environment.FromContext(ctx))
+	return err
+}

--- a/pkg/resources/cronjob/cronjob.yaml
+++ b/pkg/resources/cronjob/cronjob.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  {{ if .annotations }}
+  annotations:
+    {{ range $key, $value := .annotations }}
+    {{ $key }}: "{{ $value }}"
+    {{ end }}
+  {{ end }}
+  {{ if .labels }}
+  labels:
+    {{ range $key, $value := .labels }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
+  {{ end }}
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    metadata:
+      labels:
+        app: {{ .name }}
+    spec:
+      {{ if .backoffLimit }}
+      backoffLimit: {{ .backoffLimit }}
+      {{ end }}
+      {{ if .ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+      {{ end }}
+      template:
+        {{ if or .podannotations .podlabels }}
+        metadata:
+          {{ if .podannotations }}
+          annotations:
+            {{ range $key, $value := .podannotations }}
+            {{ $key }}: "{{ $value }}"
+            {{ end }}
+          {{ end }}
+          {{ if .podlabels }}
+          labels:
+            {{ range $key, $value := .podlabels }}
+            {{ $key }}: {{ $value }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+        spec:
+          {{ if .podSecurityContext }}
+          securityContext:
+            runAsNonRoot: {{ .podSecurityContext.runAsNonRoot }}
+            seccompProfile:
+              type: {{ .podSecurityContext.seccompProfile.type }}
+          {{ end }}
+          {{ if .restartPolicy }}
+          restartPolicy: {{ .restartPolicy }}
+          {{ end }}
+          containers:
+            - name: user-container
+              image: {{ .image }}
+              {{ if .envs }}
+              env:
+              {{ range $key, $value := .envs }}
+              - name: {{ printf "%q" $key }}
+                value: {{ printf "%q" $value }}
+              {{ end }}
+              {{ end }}
+              {{ if .containerSecurityContext }}
+              securityContext:
+                capabilities:
+                  {{ if .containerSecurityContext.capabilities.drop }}
+                  drop:
+                  {{ range $_, $value := .containerSecurityContext.capabilities.drop }}
+                  - {{ $value }}
+                  {{ end }}
+                  {{ end }}
+                  {{ if .containerSecurityContext.capabilities.add }}
+                  add:
+                  {{ range $_, $value := .containerSecurityContext.capabilities.add }}
+                  - {{ $value }}
+                  {{ end }}
+                  {{ end }}
+                allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
+              {{ end }}
+              {{ if .imagePullPolicy }}
+              imagePullPolicy: {{ .imagePullPolicy }}
+              {{ end }}

--- a/pkg/resources/cronjob/cronjob_test.go
+++ b/pkg/resources/cronjob/cronjob_test.go
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cronjob_test
+
+import (
+	"embed"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+
+	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/job"
+
+	testlog "knative.dev/reconciler-test/pkg/logging"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Example_min() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: CronJob
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   schedule: "* * * * *"
+	//   jobTemplate:
+	//     metadata:
+	//       labels:
+	//         app: foo
+	//     spec:
+	//       template:
+	//         spec:
+	//           containers:
+	//             - name: user-container
+	//               image: baz
+}
+
+func Example_full() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+	}
+
+	opts := []manifest.CfgFn{
+		job.WithLabels(map[string]string{
+			"color": "green",
+		}),
+		job.WithAnnotations(map[string]interface{}{
+			"app.kubernetes.io/name": "app",
+		}),
+		job.WithPodLabels(map[string]string{
+			"app": "my-app",
+		}),
+		job.WithPodAnnotations(map[string]interface{}{
+			"pod-annotation": "foo",
+		}),
+		job.WithRestartPolicy(v1.RestartPolicyNever),
+		job.WithImagePullPolicy(v1.PullNever),
+		job.WithBackoffLimit(20),
+		job.WithEnvs(map[string]string{
+			"VAR": "VAL",
+		}),
+		job.WithTTLSecondsAfterFinished(30),
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: batch/v1
+	// kind: CronJob
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	//   annotations:
+	//     app.kubernetes.io/name: "app"
+	//   labels:
+	//     color: green
+	// spec:
+	//   schedule: "* * * * *"
+	//   jobTemplate:
+	//     metadata:
+	//       labels:
+	//         app: foo
+	//     spec:
+	//       backoffLimit: 20
+	//       ttlSecondsAfterFinished: 30
+	//       template:
+	//         metadata:
+	//           annotations:
+	//             pod-annotation: "foo"
+	//           labels:
+	//             app: my-app
+	//         spec:
+	//           restartPolicy: Never
+	//           containers:
+	//             - name: user-container
+	//               image: baz
+	//               env:
+	//               - name: "VAR"
+	//                 value: "VAL"
+	//               imagePullPolicy: Never
+}

--- a/pkg/resources/cronjob/options.go
+++ b/pkg/resources/cronjob/options.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cronjob
+
+import (
+	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/job"
+)
+
+var (
+	WithLabels                  = manifest.WithLabels
+	WithAnnotations             = manifest.WithAnnotations
+	WithPodAnnotations          = manifest.WithPodAnnotations
+	WitEnvs                     = job.WithEnvs
+	WithPodLabels               = job.WithLabels
+	WithImagePullPolicy         = job.WithRestartPolicy
+	WithRestartPolicy           = job.WithRestartPolicy
+	WithBackoffLimit            = job.WithBackoffLimit
+	WithTTLSecondsAfterFinished = job.WithTTLSecondsAfterFinished
+)

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+	"knative.dev/reconciler-test/pkg/resources/cronjob"
+)
+
+func TestCronJobInstall(t *testing.T) {
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace("knative-reconciler-test"),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+	t.Cleanup(env.Finish)
+
+	name := feature.MakeRandomK8sName("cron")
+	sink := feature.MakeRandomK8sName("sink")
+
+	env.Test(ctx, t, eventshub.Install(sink, eventshub.StartReceiver).AsFeature())
+	env.Test(ctx, t, cronjob.Install(
+		name,
+		"gcr.io/knative-nightly/knative.dev/eventing/cmd/heartbeats",
+		cronjob.WitEnvs(map[string]string{
+			"POD_NAME":      "heartbeats",
+			"POD_NAMESPACE": environment.FromContext(ctx).Namespace(),
+			"K_SINK":        fmt.Sprintf("%s://%s.%s.svc", "http", sink, environment.FromContext(ctx).Namespace()),
+			"ONE_SHOT":      "true",
+		})).
+		AsFeature(),
+	)
+	env.Test(ctx, t, cronjob.AtLeastOneIsSucceeded(name).AsFeature())
+}


### PR DESCRIPTION
SinkBinding tests use CronJobs, this will replace the `job` package in eventing

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Support cronjobs