### PR TITLE
[WIP] Refactor image provider code

### DIFF
--- a/pkg/images/ko/publish_test.go
+++ b/pkg/images/ko/publish_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ko
+
+import (
+	"testing"
+)
+
+func TestIsGoPackage(t *testing.T) {
+	tt := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "eventshub package",
+			path:     "knative.dev/reconciler-test/cmd/eventshub",
+			expected: true,
+		},
+		{
+			name:     "built image URL",
+			path:     "gcr.io/knative-nightly/knative.dev/eventing/cmd/heartbeats",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := isGoPackage(tc.path)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if got != tc.expected {
+				t.Errorf("expected %s to be %v, got %v", tc.path, tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The code in images.go was using the pattern of defining methods on keys to get objects from the context, instead of the common pattern in Knative to have `getX(ctx context.Context) X` and
`withX(ctx context.Context, x X) context.Context`.

In addition, we were using a channel instead of a normal list to collect packages, but we only need a list there.

Now, we are also publish multiple images in parallel instead of sequencially.

Improved the check for checking whether the provided path for the ko image publisher is a Go package (see code comment for details)

<!-- Thanks for sending a pull request! -->