### PR TITLE
Support setting Job labels for cron jobs

### DIFF
--- a/pkg/resources/cronjob/cronjob.go
+++ b/pkg/resources/cronjob/cronjob.go
@@ -40,6 +40,9 @@ func Install(name string, image string, options ...manifest.CfgFn) feature.StepF
 	cfg := map[string]interface{}{
 		"name":  name,
 		"image": image,
+		"labels": map[string]string{
+			"app": name,
+		},
 	}
 
 	defaultOptions := []manifest.CfgFn{

--- a/pkg/resources/cronjob/cronjob.yaml
+++ b/pkg/resources/cronjob/cronjob.yaml
@@ -19,8 +19,12 @@ spec:
   schedule: "* * * * *"
   jobTemplate:
     metadata:
+      {{ if .labels }}
       labels:
-        app: {{ .name }}
+        {{ range $key, $value := .labels }}
+        {{ $key }}: {{ $value }}
+        {{ end }}
+      {{ end }}
     spec:
       {{ if .backoffLimit }}
       backoffLimit: {{ .backoffLimit }}

--- a/pkg/resources/cronjob/cronjob_test.go
+++ b/pkg/resources/cronjob/cronjob_test.go
@@ -38,6 +38,9 @@ func Example_min() {
 		"name":      "foo",
 		"namespace": "bar",
 		"image":     "baz",
+		"labels": map[string]string{
+			"app": "foo",
+		},
 	}
 
 	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
@@ -52,6 +55,8 @@ func Example_min() {
 	// metadata:
 	//   name: foo
 	//   namespace: bar
+	//   labels:
+	//     app: foo
 	// spec:
 	//   schedule: "* * * * *"
 	//   jobTemplate:
@@ -78,6 +83,7 @@ func Example_full() {
 	opts := []manifest.CfgFn{
 		job.WithLabels(map[string]string{
 			"color": "green",
+			"app":   "foo",
 		}),
 		job.WithAnnotations(map[string]interface{}{
 			"app.kubernetes.io/name": "app",
@@ -116,6 +122,7 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
+	//     app: foo
 	//     color: green
 	// spec:
 	//   schedule: "* * * * *"
@@ -123,6 +130,7 @@ func Example_full() {
 	//     metadata:
 	//       labels:
 	//         app: foo
+	//         color: green
 	//     spec:
 	//       backoffLimit: 20
 	//       ttlSecondsAfterFinished: 30


### PR DESCRIPTION
If the SinkBinding selection mode is set to inclusion, in eventing we need to set the `bindings.knative.dev/include: true` label on the Job to allow SinkBinding to make changes to the resulting Job.