### PR TITLE
Quote label values for cronjob

### DIFF
--- a/pkg/resources/cronjob/cronjob.yaml
+++ b/pkg/resources/cronjob/cronjob.yaml
@@ -12,7 +12,7 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 spec:
@@ -22,7 +22,7 @@ spec:
       {{ if .labels }}
       labels:
         {{ range $key, $value := .labels }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{ end }}
       {{ end }}
     spec:

--- a/pkg/resources/cronjob/cronjob_test.go
+++ b/pkg/resources/cronjob/cronjob_test.go
@@ -56,13 +56,13 @@ func Example_min() {
 	//   name: foo
 	//   namespace: bar
 	//   labels:
-	//     app: foo
+	//     app: "foo"
 	// spec:
 	//   schedule: "* * * * *"
 	//   jobTemplate:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       template:
 	//         spec:
@@ -84,6 +84,7 @@ func Example_full() {
 		job.WithLabels(map[string]string{
 			"color": "green",
 			"app":   "foo",
+			"bar":   "true",
 		}),
 		job.WithAnnotations(map[string]interface{}{
 			"app.kubernetes.io/name": "app",
@@ -122,15 +123,17 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     app: foo
-	//     color: green
+	//     app: "foo"
+	//     bar: "true"
+	//     color: "green"
 	// spec:
 	//   schedule: "* * * * *"
 	//   jobTemplate:
 	//     metadata:
 	//       labels:
-	//         app: foo
-	//         color: green
+	//         app: "foo"
+	//         bar: "true"
+	//         color: "green"
 	//     spec:
 	//       backoffLimit: 20
 	//       ttlSecondsAfterFinished: 30


### PR DESCRIPTION
Labels like `foo: true` are invalid, so we need to quote them.
