### PR TITLE
Quote label and selector values

### DIFF
--- a/pkg/resources/cronjob/cronjob.yaml
+++ b/pkg/resources/cronjob/cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           {{ if .podlabels }}
           labels:
             {{ range $key, $value := .podlabels }}
-            {{ $key }}: {{ $value }}
+            {{ $key }}: "{{ $value }}"
             {{ end }}
           {{ end }}
         {{ end }}

--- a/pkg/resources/cronjob/cronjob_test.go
+++ b/pkg/resources/cronjob/cronjob_test.go
@@ -142,7 +142,7 @@ func Example_full() {
 	//           annotations:
 	//             pod-annotation: "foo"
 	//           labels:
-	//             app: my-app
+	//             app: "my-app"
 	//         spec:
 	//           restartPolicy: Never
 	//           containers:

--- a/pkg/resources/deployment/deployment.yaml
+++ b/pkg/resources/deployment/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 spec:
@@ -22,7 +22,7 @@ spec:
   selector:
     matchLabels:
       {{ range $key, $value := .selectors }}
-      {{ $key }}: {{ $value }}
+      {{ $key }}: "{{ $value }}"
       {{ end }}
   template:
     metadata:
@@ -34,7 +34,7 @@ spec:
       {{ end }}
       labels:
         {{ range $key, $value := .selectors }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
       {{ if .podSecurityContext }}

--- a/pkg/resources/deployment/deployment_test.go
+++ b/pkg/resources/deployment/deployment_test.go
@@ -55,11 +55,11 @@ func Example_min() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -118,18 +118,18 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 	// spec:
 	//   replicas: 6
 	//   selector:
 	//     matchLabels:
-	//       app: my-app
+	//       app: "my-app"
 	//   template:
 	//     metadata:
 	//       annotations:
 	//         pod-annotation: "foo"
 	//       labels:
-	//         app: my-app
+	//         app: "my-app"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -177,13 +177,13 @@ func Example_withSelectors() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       sel1: val1
-	//       sel2: val2
+	//       sel1: "val1"
+	//       sel2: "val2"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         sel1: val1
-	//         sel2: val2
+	//         sel1: "val1"
+	//         sel2: "val2"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -220,13 +220,13 @@ func Example_withPodAnnotations() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       annotations:
 	//         pod-annotation: "foo"
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -261,11 +261,11 @@ func Example_withReplicas() {
 	//   replicas: 6
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -299,11 +299,11 @@ func Example_withPullPolicy() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -340,11 +340,11 @@ func Example_withEnv() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -382,11 +382,11 @@ func Example_withCommand() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -425,11 +425,11 @@ func Example_withArgs() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container
@@ -467,11 +467,11 @@ func Example_withPort() {
 	// spec:
 	//   selector:
 	//     matchLabels:
-	//       app: foo
+	//       app: "foo"
 	//   template:
 	//     metadata:
 	//       labels:
-	//         app: foo
+	//         app: "foo"
 	//     spec:
 	//       containers:
 	//       - name: user-container

--- a/pkg/resources/job/job.yaml
+++ b/pkg/resources/job/job.yaml
@@ -12,7 +12,7 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 spec:
@@ -34,7 +34,7 @@ spec:
       {{ if .podlabels }}
       labels:
         {{ range $key, $value := .podlabels }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{ end }}
       {{ end }}
     {{ end }}

--- a/pkg/resources/job/job_test.go
+++ b/pkg/resources/job/job_test.go
@@ -109,7 +109,7 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 	// spec:
 	//   backoffLimit: 20
 	//   ttlSecondsAfterFinished: 30
@@ -118,7 +118,7 @@ func Example_full() {
 	//       annotations:
 	//         pod-annotation: "foo"
 	//       labels:
-	//         app: my-app
+	//         app: "my-app"
 	//     spec:
 	//       restartPolicy: Never
 	//       containers:
@@ -233,8 +233,8 @@ func Example_WithPodLabels() {
 	//   template:
 	//     metadata:
 	//       labels:
-	//         color: blue
-	//         version: 3
+	//         color: "blue"
+	//         version: "3"
 	//     spec:
 	//       containers:
 	//       - name: job-container

--- a/pkg/resources/namespace/namespace.yaml
+++ b/pkg/resources/namespace/namespace.yaml
@@ -11,6 +11,6 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}

--- a/pkg/resources/namespace/namespace_test.go
+++ b/pkg/resources/namespace/namespace_test.go
@@ -82,5 +82,5 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 }

--- a/pkg/resources/pod/pod.yaml
+++ b/pkg/resources/pod/pod.yaml
@@ -26,7 +26,7 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 spec:

--- a/pkg/resources/pod/pod_test.go
+++ b/pkg/resources/pod/pod_test.go
@@ -100,7 +100,7 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 	// spec:
 	//   containers:
 	//   - name: user-container

--- a/pkg/resources/secret/secret.yaml
+++ b/pkg/resources/secret/secret.yaml
@@ -12,7 +12,7 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 {{ if .type }}

--- a/pkg/resources/secret/secret_test.go
+++ b/pkg/resources/secret/secret_test.go
@@ -95,7 +95,7 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 	// type: Opaque
 	// data:
 	//   key1: dmFsMQ==

--- a/pkg/resources/service/service.yaml
+++ b/pkg/resources/service/service.yaml
@@ -26,14 +26,14 @@ metadata:
   {{ if .labels }}
   labels:
     {{ range $key, $value := .labels }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
 spec:
   {{ if .selectors }}
   selector:
     {{ range $key, $value := .selectors }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: "{{ $value }}"
     {{ end }}
   {{ end }}
   ports:

--- a/pkg/resources/service/service_test.go
+++ b/pkg/resources/service/service_test.go
@@ -106,10 +106,10 @@ func Example_full() {
 	//   annotations:
 	//     app.kubernetes.io/name: "app"
 	//   labels:
-	//     color: green
+	//     color: "green"
 	// spec:
 	//   selector:
-	//     app.kubernetes.io/name: foobar
+	//     app.kubernetes.io/name: "foobar"
 	//   ports:
 	//     - protocol: TCP
 	//       port: 1234
@@ -149,8 +149,8 @@ func Example_WithSelectors() {
 	//   namespace: bar
 	// spec:
 	//   selector:
-	//     color: blue
-	//     version: 3
+	//     color: "blue"
+	//     version: "3"
 	//   ports:
 	//     - protocol: TCP
 	//       port: 1234


### PR DESCRIPTION
Follow up on #503 to quote labels and selectors of all existing resources:

Labels like `foo: true` are invalid, so we need to quote them.