### PR TITLE
Knative Service forwarder for EventsHub

### DIFF
--- a/cmd/eventshub/main.go
+++ b/cmd/eventshub/main.go
@@ -49,7 +49,7 @@ func main() {
 			eventshub.ForwarderEventGenerator: func(ctx context.Context, logs *eventshub.EventLogs) error {
 				return forwarder.NewFromEnv(ctx, logs,
 					[]eventshub.HandlerFunc{eventshub.WithServerTracing},
-					[]eventshub.Option{eventshub.WithClientTracing}).Start(ctx)
+					[]eventshub.ClientOption{eventshub.WithClientTracing}).Start(ctx)
 			},
 		},
 	)

--- a/cmd/eventshub/main.go
+++ b/cmd/eventshub/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"knative.dev/pkg/logging"
+	"knative.dev/reconciler-test/pkg/eventshub/forwarder"
 
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/logger_vent"
@@ -44,6 +45,11 @@ func main() {
 			},
 			eventshub.SenderEventGenerator: func(ctx context.Context, logs *eventshub.EventLogs) error {
 				return sender.Start(ctx, logs, eventshub.WithClientTracing)
+			},
+			eventshub.ForwarderEventGenerator: func(ctx context.Context, logs *eventshub.EventLogs) error {
+				return forwarder.NewFromEnv(ctx, logs,
+					[]eventshub.HandlerFunc{eventshub.WithServerTracing},
+					[]eventshub.Option{eventshub.WithClientTracing}).Start(ctx)
 			},
 		},
 	)

--- a/pkg/eventshub/102-service.yaml
+++ b/pkg/eventshub/102-service.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .name }}
+  name: {{ .serviceName }}
   namespace: {{ .namespace }}
 spec:
   selector:

--- a/pkg/eventshub/104-forwarder.yaml
+++ b/pkg/eventshub/104-forwarder.yaml
@@ -1,0 +1,50 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  {{ if .annotations }}
+  annotations:
+    {{ range $key, $value := .annotations }}
+      {{ $key }}: "{{ $value }}"
+      {{ end }}
+  {{ end }}
+spec:
+  template:
+    {{ if .podannotations }}
+    annotations:
+      {{ range $key, $value := .podannotations }}
+        {{ $key }}: "{{ $value }}"
+        {{ end }}
+    {{ end }}
+    spec:
+      serviceAccountName: "{{ .namespace }}"
+      containers:
+        - name: eventshub-forwarder
+          image: {{ .image }}
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: "NAME"
+              value: {{ .name }}
+            - name: "NAMESPACE"
+              value: {{ .namespace }}
+            - name: "SINK"
+              value: {{ .sink }}
+            {{ range $key, $value := .envs }}
+            - name: {{printf "%q" $key}}
+              value: {{printf "%q" $value}}
+            {{ end }}

--- a/pkg/eventshub/event_log.go
+++ b/pkg/eventshub/event_log.go
@@ -45,8 +45,9 @@ func (e *EventLogs) Vent(observed EventInfo) error {
 }
 
 const (
-	ReceiverEventGenerator string = "receiver"
-	SenderEventGenerator   string = "sender"
+	ReceiverEventGenerator  string = "receiver"
+	SenderEventGenerator    string = "sender"
+	ForwarderEventGenerator string = "forwarder"
 
 	RecorderEventLog string = "recorder"
 	LoggerEventLog   string = "logger"

--- a/pkg/eventshub/eventshub_image.go
+++ b/pkg/eventshub/eventshub_image.go
@@ -31,7 +31,7 @@ func ImageFromContext(ctx context.Context) string {
 	if e, ok := ctx.Value(eventshubImageKey{}).(string); ok {
 		return e
 	}
-	return "ko://" + cmdPackage()
+	return "ko://" + eventshubPackage()
 }
 
 // WithCustomImage allows you to specify a custom eventshub image to be used when invoking eventshub.Install
@@ -48,7 +48,7 @@ func registerImage(ctx context.Context) error {
 	return err
 }
 
-func cmdPackage() string {
+func eventshubPackage() string {
 	this := reflect.TypeOf(eventshubImageKey{}).PkgPath()
 	root := path.Dir(path.Dir(this))
 	return path.Join(root, "cmd", "eventshub")

--- a/pkg/eventshub/forwarder/forwarder.go
+++ b/pkg/eventshub/forwarder/forwarder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2023 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ type Forwarder struct {
 
 	ctx          context.Context
 	handlerFuncs []eventshub.HandlerFunc
-	clientOpts   []eventshub.Option
+	clientOpts   []eventshub.ClientOption
 	httpClient   *http.Client
 }
 
@@ -68,7 +68,7 @@ type envConfig struct {
 	Sink string `envconfig:"SINK" required:"true"`
 }
 
-func NewFromEnv(ctx context.Context, eventLogs *eventshub.EventLogs, handlerFuncs []eventshub.HandlerFunc, clientOpts []eventshub.Option) *Forwarder {
+func NewFromEnv(ctx context.Context, eventLogs *eventshub.EventLogs, handlerFuncs []eventshub.HandlerFunc, clientOpts []eventshub.ClientOption) *Forwarder {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
 		logging.FromContext(ctx).Fatal("Failed to process env var", err)

--- a/pkg/eventshub/forwarder/forwarder.go
+++ b/pkg/eventshub/forwarder/forwarder.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forwarder
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cloudeventsbindings "github.com/cloudevents/sdk-go/v2/binding"
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	cloudeventshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/kelseyhightower/envconfig"
+	"knative.dev/pkg/logging"
+
+	"knative.dev/reconciler-test/pkg/eventshub"
+)
+
+// Forwarder is the entry point for sinking events into the event log.
+type Forwarder struct {
+	// Name is the name of this Forwarder.
+	Name string
+
+	// The current namespace.
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
+
+	// Sink
+	Sink string
+
+	// EventLogs is the list of EventLogger implementors to vent observed events.
+	EventLogs *eventshub.EventLogs
+
+	ctx          context.Context
+	handlerFuncs []eventshub.HandlerFunc
+	clientOpts   []eventshub.Option
+	httpClient   *http.Client
+}
+
+type envConfig struct {
+	// Name is used to identify this instance of the forwarder.
+	Name string `envconfig:"NAME" default:"forwarder-default" required:"true"`
+
+	// The current namespace.
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
+
+	// Sink url for the message destination
+	Sink string `envconfig:"SINK" required:"true"`
+}
+
+func NewFromEnv(ctx context.Context, eventLogs *eventshub.EventLogs, handlerFuncs []eventshub.HandlerFunc, clientOpts []eventshub.Option) *Forwarder {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		logging.FromContext(ctx).Fatal("Failed to process env var", err)
+	}
+
+	logging.FromContext(ctx).Infof("Forwarder environment configuration: %+v", env)
+
+	return &Forwarder{
+		Name:         env.Name,
+		Namespace:    env.Namespace,
+		Sink:         env.Sink,
+		EventLogs:    eventLogs,
+		ctx:          ctx,
+		handlerFuncs: handlerFuncs,
+		clientOpts:   clientOpts,
+		httpClient:   &http.Client{},
+	}
+}
+
+// Start will create the CloudEvents client and start listening for inbound
+// HTTP requests. This is a blocking call.
+func (o *Forwarder) Start(ctx context.Context) error {
+	var handler http.Handler = o
+
+	for _, opt := range o.clientOpts {
+		if err := opt(o.httpClient); err != nil {
+			return fmt.Errorf("unable to apply client option: %w", err)
+		}
+	}
+
+	for _, dec := range o.handlerFuncs {
+		handler = dec(handler)
+	}
+
+	server := &http.Server{Addr: ":8080", Handler: handler}
+
+	var err error
+	go func() {
+		err = server.ListenAndServe()
+	}()
+
+	<-ctx.Done()
+
+	if err != nil {
+		return fmt.Errorf("error while starting the HTTP server: %w", err)
+	}
+
+	logging.FromContext(ctx).Info("Closing the HTTP server")
+
+	return server.Close()
+}
+
+func (o *Forwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	ctx, span := trace.StartSpan(o.ctx, "eventshub-forwarder")
+	defer span.End()
+
+	m := cloudeventshttp.NewMessageFromHttpRequest(request)
+	defer m.Finish(nil)
+
+	event, eventErr := cloudeventsbindings.ToEvent(context.TODO(), m)
+	headers := make(http.Header)
+	for k, v := range request.Header {
+		if !strings.HasPrefix(k, "Ce-") {
+			headers[k] = v
+		}
+	}
+	// Host header is removed from the request.Header map by net/http
+	if request.Host != "" {
+		headers.Set("Host", request.Host)
+	}
+
+	eventErrStr := ""
+	if eventErr != nil {
+		eventErrStr = eventErr.Error()
+	}
+
+	eventInfo := eventshub.EventInfo{
+		Error:       eventErrStr,
+		Event:       event,
+		Observer:    o.Name,
+		HTTPHeaders: headers,
+		Origin:      request.RemoteAddr,
+		Time:        time.Now(),
+		Kind:        eventshub.EventReceived,
+	}
+
+	// Log the event that is being forwarded
+	if err := o.EventLogs.Vent(eventInfo); err != nil {
+		logging.FromContext(o.ctx).Fatalw("Error while venting the received event", zap.Error(err))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.Sink, nil)
+	if err != nil {
+		logging.FromContext(ctx).Error("Cannot create the request: ", err)
+	}
+	err = cehttp.WriteRequest(ctx, m, req)
+	if err != nil {
+		logging.FromContext(ctx).Error("Cannot write the event: ", err)
+	}
+
+	eventString := "unknown"
+	if event != nil {
+		eventString = event.String()
+	}
+	span.AddAttributes(
+		trace.StringAttribute("namespace", o.Namespace),
+		trace.StringAttribute("event", eventString),
+	)
+
+	res, err := o.httpClient.Do(req)
+
+	// Publish sent event info
+	if err := o.EventLogs.Vent(o.sentInfo(event, req, err)); err != nil {
+		logging.FromContext(ctx).Error("Cannot log forwarded event: ", err)
+	}
+
+	if err == nil {
+		// Vent the response info
+		if err := o.EventLogs.Vent(o.responseInfo(res, event)); err != nil {
+			logging.FromContext(ctx).Error("Cannot log response for forwarded event: ", err)
+		}
+	}
+
+	writer.WriteHeader(http.StatusAccepted)
+}
+
+func (o *Forwarder) sentInfo(event *cloudevents.Event, req *http.Request, err error) eventshub.EventInfo {
+	var eventId string
+	if event != nil {
+		eventId = event.ID()
+	}
+
+	eventInfo := eventshub.EventInfo{
+		Kind:     eventshub.EventSent,
+		Origin:   o.Name,
+		Observer: o.Name,
+		Time:     time.Now(),
+		SentId:   eventId,
+	}
+
+	sentHeaders := make(http.Header)
+	for k, v := range req.Header {
+		sentHeaders[k] = v
+	}
+	eventInfo.HTTPHeaders = sentHeaders
+
+	if err != nil {
+		eventInfo.Error = err.Error()
+	} else {
+		eventInfo.Event = event
+	}
+
+	return eventInfo
+}
+
+func (o *Forwarder) responseInfo(res *http.Response, event *cloudevents.Event) eventshub.EventInfo {
+	var eventId string
+	if event != nil {
+		eventId = event.ID()
+	}
+
+	responseInfo := eventshub.EventInfo{
+		Kind:        eventshub.EventResponse,
+		HTTPHeaders: res.Header,
+		Origin:      o.Sink,
+		Observer:    o.Name,
+		Time:        time.Now(),
+		StatusCode:  res.StatusCode,
+		SentId:      eventId,
+	}
+
+	responseMessage := cehttp.NewMessageFromHttpResponse(res)
+
+	if responseMessage.ReadEncoding() == cloudeventsbindings.EncodingUnknown {
+		body, err := ioutil.ReadAll(res.Body)
+
+		if err != nil {
+			responseInfo.Error = err.Error()
+		} else {
+			responseInfo.Body = body
+		}
+	} else {
+		responseEvent, err := cloudeventsbindings.ToEvent(context.Background(), responseMessage)
+		if err != nil {
+			responseInfo.Error = err.Error()
+		} else {
+			responseInfo.Event = responseEvent
+		}
+	}
+	return responseInfo
+}

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -125,12 +125,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			envs[EventGeneratorsEnv] = "forwarder"
 			// No event recording desired, just logging.
 			envs[EventLogsEnv] = "logger"
-			cfg := map[string]interface{}{
-				"name":  name,
-				"envs":  envs,
-				"image": ImageFromContext(ctx),
-				"sink":  sinkURL,
-			}
+			cfg["envs"] = envs
+			cfg["sink"] = sinkURL
+
 			// Deploy Forwarder
 			if _, err := manifest.InstallYamlFS(ctx, forwarderTemplates, cfg); err != nil {
 				log.Fatal(err)

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -22,17 +22,21 @@ import (
 	"strings"
 
 	"knative.dev/pkg/logging"
-
 	"knative.dev/reconciler-test/pkg/environment"
 	eventshubrbac "knative.dev/reconciler-test/pkg/eventshub/rbac"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/pkg/resources/knativeservice"
+	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
-//go:embed *.yaml
-var templates embed.FS
+//go:embed 102-service.yaml 103-pod.yaml
+var servicePodTemplates embed.FS
+
+//go:embed 104-forwarder.yaml
+var forwarderTemplates embed.FS
 
 // Install starts a new eventshub with the provided name
 // Note: this function expects that the Environment is configured with the
@@ -70,10 +74,24 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		// Install ServiceAccount, Role, RoleBinding
 		eventshubrbac.Install()(ctx, t)
 
-		isReceiver := strings.Contains(envs["EVENT_GENERATORS"], "receiver")
+		isReceiver := strings.Contains(envs[EventGeneratorsEnv], "receiver")
+
+		var withForwarder bool
+		// Allow forwarder only when eventshub is receiver.
+		if isForwarder(ctx) && isReceiver {
+			withForwarder = isForwarder(ctx)
+		}
+
+		serviceName := name
+		// When forwarder is included we need to rename the eventshub service to
+		// prevent conflict with the forwarder service.
+		if withForwarder {
+			serviceName = feature.MakeRandomK8sName(name)
+		}
 
 		cfg := map[string]interface{}{
 			"name":          name,
+			"serviceName":   serviceName,
 			"envs":          envs,
 			"image":         ImageFromContext(ctx),
 			"withReadiness": isReceiver,
@@ -85,8 +103,8 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)
 
-		// Deploy
-		if _, err := manifest.InstallYamlFS(ctx, templates, cfg); err != nil {
+		// Deploy Service/Pod
+		if _, err := manifest.InstallYamlFS(ctx, servicePodTemplates, cfg); err != nil {
 			log.Fatal(err)
 		}
 
@@ -94,8 +112,30 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 
 		// If the eventhubs starts an event receiver, we need to wait for the service endpoint to be synced
 		if isReceiver {
-			k8s.WaitForServiceEndpointsOrFail(ctx, t, name, 1)
-			k8s.WaitForServiceReadyOrFail(ctx, t, name, "/health/ready")
+			k8s.WaitForServiceEndpointsOrFail(ctx, t, serviceName, 1)
+			k8s.WaitForServiceReadyOrFail(ctx, t, serviceName, "/health/ready")
+		}
+
+		if withForwarder {
+			sinkURL, err := service.Address(ctx, serviceName)
+			if err != nil {
+				log.Fatal(err)
+			}
+			// At this point env contains "receiver" so we need to override it.
+			envs[EventGeneratorsEnv] = "forwarder"
+			// No event recording desired, just logging.
+			envs[EventLogsEnv] = "logger"
+			cfg := map[string]interface{}{
+				"name":  name,
+				"envs":  envs,
+				"image": ImageFromContext(ctx),
+				"sink":  sinkURL,
+			}
+			// Deploy Forwarder
+			if _, err := manifest.InstallYamlFS(ctx, forwarderTemplates, cfg); err != nil {
+				log.Fatal(err)
+			}
+			knativeservice.IsReady(name)
 		}
 	}
 }

--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -107,7 +107,7 @@ type generator struct {
 	eventQueue []conformanceevent.Event
 }
 
-func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventshub.Option) error {
+func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventshub.ClientOption) error {
 	var env generator
 	if err := envconfig.Process("", &env); err != nil {
 		return fmt.Errorf("failed to process env var. %w", err)

--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -107,9 +107,7 @@ type generator struct {
 	eventQueue []conformanceevent.Event
 }
 
-type Option func(*nethttp.Client) error
-
-func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...Option) error {
+func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventshub.Option) error {
 	var env generator
 	if err := envconfig.Process("", &env); err != nil {
 		return fmt.Errorf("failed to process env var. %w", err)

--- a/pkg/eventshub/utils.go
+++ b/pkg/eventshub/utils.go
@@ -33,8 +33,10 @@ import (
 )
 
 const (
-	ConfigTracingEnv = "K_CONFIG_TRACING"
-	ConfigLoggingEnv = "K_CONFIG_LOGGING"
+	ConfigTracingEnv   = "K_CONFIG_TRACING"
+	ConfigLoggingEnv   = "K_CONFIG_LOGGING"
+	EventGeneratorsEnv = "EVENT_GENERATORS"
+	EventLogsEnv       = "EVENT_LOGS"
 )
 
 func ParseHeaders(serializedHeaders string) http.Header {
@@ -115,3 +117,6 @@ func WithClientTracing(client *http.Client) error {
 	}
 	return nil
 }
+
+type HandlerFunc func(handler http.Handler) http.Handler
+type Option func(*http.Client) error

--- a/pkg/eventshub/utils.go
+++ b/pkg/eventshub/utils.go
@@ -119,4 +119,4 @@ func WithClientTracing(client *http.Client) error {
 }
 
 type HandlerFunc func(handler http.Handler) http.Handler
-type Option func(*http.Client) error
+type ClientOption func(*http.Client) error

--- a/pkg/resources/knativeservice/ksvc.go
+++ b/pkg/resources/knativeservice/ksvc.go
@@ -1,0 +1,18 @@
+package knativeservice
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+)
+
+func GVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
+}
+
+// IsReady tests to see if a knative Service becomes ready within the time given.
+func IsReady(name string, timings ...time.Duration) feature.StepFn {
+	return k8s.IsReady(GVR(), name, timings...)
+}

--- a/pkg/resources/knativeservice/ksvc.go
+++ b/pkg/resources/knativeservice/ksvc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package knativeservice
 
 import (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift:
- Add option for global environment to enable Knative Service Forwarder for EventsHub receiver:
```
ctx, env := global.Environment(eventshub.WithKnativeServiceForwarder)
```
- Implement forwarder that combines functionality from receiver and sender. It logs the events that are forwarded but doesn't record them (it doesn't send a k8s event for them).
- Tests which use EventsHub can stay untouched if they don't want to use the Knative Service forwarder. Tests which want to use it can re-use Features from other tests and only configure global environment like in the example below:
```
func TestPingSourceBrokerTriggerKsvc(t *testing.T) {
	t.Parallel()

	ctx, env := global.Environment(
		knative.WithKnativeNamespace(system.Namespace()),
		knative.WithLoggingConfig,
		knative.WithTracingConfig,
		k8s.WithEventListener,
                // vvv------ This line enables KSVC forwarder. Other lines are unchanged.
		eventshub.WithKnativeServiceForwarder,
		environment.Managed(t),
	)

        // features.SendsEventsWithSinkRef is reused (not changed)
	env.Test(ctx, t, features.SendsEventsWithSinkRef())
}
```

Other alternatives considered:
* Having EventsHub itself as Knative Service (vs. using the forwarder KSVC) - this approach has some drawbacks: The EventsHub records events and includes ObjectReference to the Pod that sends/receives the Event. This is problematic with Knative Serving because it might scale up and then there's no good way to get info about the concrete pod that is running.  It would have to be limited to `max-scale=1` which is kind of limiting for the desired usecases. This limitation is not there with the forwarder approach.
* Provide Knative Service as a separate StepFn - this limits the re-use of the whole Feature when someone want to test it together with Knative Service. It's no longer possible to re-use the whole Feature but it's required to re-implement it and add the KSVC in the scenario manually.


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #516

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
