### PR TITLE
Remove resources when terminating the environment

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -129,14 +129,9 @@ func (mr *MagicEnvironment) Finish() {
 	if mr.managedT != nil {
 		result = mr.managedT
 		if !result.Failed() {
-			refFailedDeletion, err := feature.DeleteResources(mr.c, mr.managedT, mr.References())
-			if err != nil {
+			if err := feature.DeleteResources(mr.c, mr.managedT, mr.References()); err != nil {
 				mr.managedT.Fatal(err)
 			}
-
-			mr.refsMu.Lock()
-			mr.refs = refFailedDeletion
-			mr.refsMu.Unlock()
 		}
 	}
 	if mr.milestones != nil {

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -128,6 +128,16 @@ func (mr *MagicEnvironment) Finish() {
 	var result milestone.Result = unknownResult{}
 	if mr.managedT != nil {
 		result = mr.managedT
+		if !result.Failed() {
+			refFailedDeletion, err := feature.DeleteResources(mr.c, mr.managedT, mr.References())
+			if err != nil {
+				mr.managedT.Fatal(err)
+			}
+
+			mr.refsMu.Lock()
+			mr.refs = refFailedDeletion
+			mr.refsMu.Unlock()
+		}
 	}
 	if mr.milestones != nil {
 		mr.milestones.Finished(result)

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -195,8 +195,6 @@ func (f *Feature) References() []corev1.ObjectReference {
 // DeleteResources delete all known resources to the Feature registered
 // via `Reference`.
 //
-// Use References to get the undeleted resources.
-//
 // Expected to be used as a StepFn.
 func (f *Feature) DeleteResources(ctx context.Context, t T) {
 	if err := DeleteResources(ctx, t, f.References()); err != nil {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -199,25 +199,19 @@ func (f *Feature) References() []corev1.ObjectReference {
 //
 // Expected to be used as a StepFn.
 func (f *Feature) DeleteResources(ctx context.Context, t T) {
-	refFailedDeletion, err := DeleteResources(ctx, t, f.References())
-	if err != nil {
+	if err := DeleteResources(ctx, t, f.References()); err != nil {
 		t.Fatal(err)
 	}
-
-	f.refsMu.Lock()
-	defer f.refsMu.Unlock()
-
-	f.refs = refFailedDeletion
 }
 
-func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) ([]corev1.ObjectReference, error) {
+func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) error {
 	dc := dynamicclient.Get(ctx)
 
 	for _, ref := range refs {
 
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse GroupVersion for %+v", ref.APIVersion)
+			return fmt.Errorf("could not parse GroupVersion for %+v", ref.APIVersion)
 		}
 
 		resource := apis.KindToResource(gv.WithKind(ref.Kind))
@@ -235,11 +229,7 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) ([
 		}
 	}
 
-	// refFailedDeletion keeps the failed to delete resources.
-	var refFailedDeletion []corev1.ObjectReference
-
 	err := wait.Poll(time.Second, 4*time.Minute, func() (bool, error) {
-		refFailedDeletion = nil // Reset failed deletion.
 		for _, ref := range refs {
 			gv, err := schema.ParseGroupVersion(ref.APIVersion)
 			if err != nil {
@@ -256,7 +246,7 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) ([
 				continue
 			}
 			if err != nil {
-				refFailedDeletion = append(refFailedDeletion, ref)
+				LogReferences(ref)(ctx, t)
 				return false, fmt.Errorf("failed to get resource %+v %s/%s: %w", resource, ref.Namespace, ref.Name, err)
 			}
 
@@ -267,11 +257,10 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) ([
 		return true, nil
 	})
 	if err != nil {
-		LogReferences(refFailedDeletion...)(ctx, t)
-		return nil, fmt.Errorf("failed to wait for resources to be deleted: %v", err)
+		return fmt.Errorf("failed to wait for resources to be deleted: %v", err)
 	}
 
-	return refFailedDeletion, nil
+	return nil
 }
 
 var (


### PR DESCRIPTION
When calling env.Finish() the resources that have been created by such environment should be removed.

So far, we were relying on the namespace deletion to clean up resources, however, if a precreated namespace is used for multiple tests and multiple environments, the cluster is full of resources that are not needed anymore since those tests were successfully run.