### PR TITLE
Add support for feature-level prerequisites

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -2,13 +2,14 @@ package environment
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
 func categorizeSteps(steps []feature.Step) map[feature.Timing][]feature.Step {
-	stepsByTiming := make(map[feature.Timing][]feature.Step, 4)
+	stepsByTiming := make(map[feature.Timing][]feature.Step, len(feature.Timings()))
 
 	for _, timing := range feature.Timings() {
 		stepsByTiming[timing] = filterStepTimings(steps, timing)
@@ -27,18 +28,18 @@ func filterStepTimings(steps []feature.Step, timing feature.Timing) []feature.St
 	return res
 }
 
-func (mr *MagicEnvironment) executeOptional(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step) {
+func (mr *MagicEnvironment) executeOptional(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step, aggregator *stepExecutionAggregator) {
 	t.Helper()
-	mr.executeStep(ctx, t, f, s, createSkippingT)
+	mr.executeStep(ctx, t, f, s, createSkippingT, aggregator)
 }
 
 // execute executes the step in a sub test without wrapping t.
-func (mr *MagicEnvironment) execute(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step) {
+func (mr *MagicEnvironment) execute(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step, aggregator *stepExecutionAggregator) {
 	t.Helper()
-	mr.executeStep(ctx, t, f, s, func(t *testing.T) feature.T { return t })
+	mr.executeStep(ctx, t, f, s, func(t *testing.T) feature.T { return t }, aggregator)
 }
 
-func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T) {
+func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *feature.Feature, s *feature.Step, tDecorator func(t *testing.T) feature.T, aggregator *stepExecutionAggregator) {
 	t.Helper()
 
 	t.Run(s.Name, func(t *testing.T) {
@@ -64,5 +65,53 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *fe
 
 		// Perform step.
 		s.Fn(internalCtx, ft)
+
+		if ft.Failed() {
+			aggregator.AddFailed(s)
+		} else {
+			aggregator.AddSucceeded(s)
+		}
 	})
+}
+
+// stepExecutionAggregator aggregates various parallel steps results.
+//
+// It needs to be thread safe since steps run in parallel.
+type stepExecutionAggregator struct {
+	failed  map[string]*feature.Step
+	success map[string]*feature.Step
+	mu      sync.Mutex
+}
+
+func newStepExecutionAggregator() *stepExecutionAggregator {
+	return &stepExecutionAggregator{
+		failed:  make(map[string]*feature.Step, 2),
+		success: make(map[string]*feature.Step, 2),
+		mu:      sync.Mutex{},
+	}
+}
+
+func (er *stepExecutionAggregator) Failed() []*feature.Step {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	failed := make([]*feature.Step, 0, len(er.failed))
+	for _, v := range er.failed {
+		failed = append(failed, v)
+	}
+	return failed
+}
+
+func (er *stepExecutionAggregator) AddFailed(step *feature.Step) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	er.failed[step.Name] = step
+}
+
+func (er *stepExecutionAggregator) AddSucceeded(step *feature.Step) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	er.success[step.Name] = step
 }

--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -18,6 +18,7 @@ package environment
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"regexp"
 	"sync"
@@ -363,8 +364,9 @@ func (mr *MagicEnvironment) test(ctx context.Context, originalT *testing.T, f *f
 	// skip is flag that signals whether the steps for the subsequent timings should
 	// be skipped because a step in a previous timing failed.
 	//
-	// Setup and Teardown steps are executed always
+	// Setup and Teardown steps are executed always except when a Prerequisite step failed.
 	skip := false
+	skipTeardown := false
 
 	originalT.Run(f.Name, func(t *testing.T) {
 
@@ -386,10 +388,14 @@ func (mr *MagicEnvironment) test(ctx context.Context, originalT *testing.T, f *f
 						steps = mr.loggingSteps()
 					}
 				}
-				skip = false
+				skip = skipTeardown
 			}
 
 			originalT.Logf("Running %d steps for timing:\n%s\n\n", len(steps), steps.String())
+
+			// aggregator aggregates steps results (success or failure) for a single timing.
+			// It used for handling the prerequisite logic.
+			aggregator := newStepExecutionAggregator()
 
 			t.Run(timing.String(), func(t *testing.T) {
 				// no parallel, various timing steps run in order: setup, requirement, assert, teardown
@@ -401,13 +407,26 @@ func (mr *MagicEnvironment) test(ctx context.Context, originalT *testing.T, f *f
 
 				for _, s := range steps {
 					s := s
-					if mr.shouldFail(&s) {
-						mr.execute(ctx, t, f, &s)
+					if mr.shouldFail(&s) && timing != feature.Prerequisite {
+						mr.execute(ctx, t, f, &s, aggregator)
 					} else {
-						mr.executeOptional(ctx, t, f, &s)
+						mr.executeOptional(ctx, t, f, &s, aggregator)
 					}
 				}
 			})
+
+			// If any step at timing feature.Prerequisite failed, we should skip the feature.
+			if timing == feature.Prerequisite {
+				failed := aggregator.Failed()
+				if len(failed) > 0 {
+					bytes, _ := json.MarshalIndent(failed, "", "  ")
+					originalT.Logf("Prerequisite steps failed, skipping the remaining timings and steps, failed prerequisite steps:\n%s\n", string(bytes))
+
+					// Skip any other subsequent timing.
+					skip = true
+					skipTeardown = true
+				}
+			}
 
 			if t.Failed() {
 				// skip the following timings since curring timing failed

--- a/pkg/feature/timing.go
+++ b/pkg/feature/timing.go
@@ -23,7 +23,10 @@ import (
 type Timing uint8
 
 const (
-	Setup Timing = iota
+	// Prerequisite timing allows having steps that are asserting whether the feature should run
+	// or not, a failed Prerequisite step will cause the other steps to be skipped.
+	Prerequisite Timing = iota
+	Setup
 	Requirement
 	Assert
 	Teardown
@@ -38,12 +41,13 @@ func (t Timing) MarshalJSON() ([]byte, error) {
 }
 
 func Timings() []Timing {
-	return []Timing{Setup, Requirement, Assert, Teardown}
+	return []Timing{Prerequisite, Setup, Requirement, Assert, Teardown}
 }
 
 var timingMapping = map[Timing]string{
-	Setup:       "Setup",
-	Requirement: "Requirement",
-	Assert:      "Assert",
-	Teardown:    "Teardown",
+	Prerequisite: "Prerequisite",
+	Setup:        "Setup",
+	Requirement:  "Requirement",
+	Assert:       "Assert",
+	Teardown:     "Teardown",
 }

--- a/pkg/milestone/emitter_log.go
+++ b/pkg/milestone/emitter_log.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
+
 	testlog "knative.dev/reconciler-test/pkg/logging"
 
 	"knative.dev/reconciler-test/pkg/feature"


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/6934

When testing TLS we are facing the challenge of defining tests which should be executed based on the feature flag value.

For example, when we will add tests for [1], we will need to execute the test only when the transport-encryption feature flag is set to one of permissive or strict.

[1] https://github.com/knative/eventing/issues/6932

The idea is to have an additional feature timing called `Prerequisite` and the usage would look like this:

```golang
	f.Prerequisite("other timings should not run", func(ctx context.Context, t feature.T) (feature.PrerequisiteResult, error) {
		// check feature flag value .. 
		// ...
		return feature.PrerequisiteResult{ShouldRun: false}, nil
	})
	f.Setup("failed setup", func(ctx context.Context, t feature.T) {
		t.Fatal("bug: this must never happen")
	})
```