### PR TITLE
Support receiving events to HTTPS endpoints in eventshub

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -80,8 +80,7 @@ jobs:
       run: |
         set -x
 
-        # Apply the reconciler test config.
-        kubectl apply -f ./test/config
+        source test/e2e-common.sh && knative_setup
 
         # Run the tests tagged as e2e on the KinD cluster.
         go run gotest.tools/gotestsum@v1.8.0 --format testname -- \

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -80,7 +80,7 @@ jobs:
       run: |
         set -x
 
-        source test/e2e-common.sh && knative_setup
+        source test/e2e-common.sh && test_setup
 
         # Run the tests tagged as e2e on the KinD cluster.
         go run gotest.tools/gotestsum@v1.8.0 --format testname -- \

--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -36,6 +36,12 @@ spec:
   {{ end }}
   containers:
     - name: eventshub
+      {{ if .withEnforceTLS }}
+      volumeMounts:
+        - name: tls-certificates
+          mountPath: "/etc/tls/certificates"
+          readOnly: true
+      {{ end }}
       {{ if .containerSecurityContext }}
       securityContext:
         capabilities:
@@ -76,3 +82,10 @@ spec:
         - name: {{printf "%q" $key}}
           value: {{printf "%q" $value}}
         {{ end }}
+  {{ if .withEnforceTLS }}
+  volumes:
+    - name: tls-certificates
+      secret:
+        secretName: server-tls-{{ .name }}
+        optional: false
+  {{ end }}

--- a/pkg/eventshub/105-certificate-ca.yaml
+++ b/pkg/eventshub/105-certificate-ca.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
+apiVersion: cert-manager.io/v1
+kind: Certificate
 metadata:
-  name: {{ .serviceName }}
+  name: selfsigned-ca
   namespace: {{ .namespace }}
 spec:
-  selector:
-    app: eventshub-{{ .name }}
-  ports:
-    - protocol: TCP
-      name: http
-      port: 80
-      targetPort: 8080
-    {{ if .withEnforceTLS }}
-    - protocol: TCP
-      name: https
-      port: 443
-      targetPort: 8443
-    {{ end }}
+  # Secret names are always required.
+  secretName: eventshub-ca
+
+  isCA: true
+  commonName: selfsigned-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/pkg/eventshub/105-certificate-service.yaml
+++ b/pkg/eventshub/105-certificate-service.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  {{ if .annotations }}
+  annotations:
+    {{ range $key, $value := .annotations }}
+      {{ $key }}: "{{ $value }}"
+      {{ end }}
+  {{ end }}
+spec:
+  # Secret names are always required.
+  secretName: server-tls-{{ .name }}
+
+  secretTemplate:
+    labels:
+      app: eventshub-{{ .name }}
+
+  duration: 1h
+  renewBefore: 30m
+  subject:
+    organizations:
+      - local
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+
+  dnsNames:
+    - {{ .serviceName }}.{{ .namespace }}.svc.cluster.local
+  ipAddresses: # used for testing and port-forwarding
+    - 127.0.0.1
+
+  issuerRef:
+    name: selfsigned-ca-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/pkg/eventshub/105-issuer-ca.yaml
+++ b/pkg/eventshub/105-issuer-ca.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
-  name: {{ .serviceName }}
+  name: selfsigned-ca-issuer
   namespace: {{ .namespace }}
 spec:
-  selector:
-    app: eventshub-{{ .name }}
-  ports:
-    - protocol: TCP
-      name: http
-      port: 80
-      targetPort: 8080
-    {{ if .withEnforceTLS }}
-    - protocol: TCP
-      name: https
-      port: 443
-      targetPort: 8443
-    {{ end }}
+  ca:
+    secretName: eventshub-ca

--- a/pkg/eventshub/105-issuer-certificate.yaml
+++ b/pkg/eventshub/105-issuer-certificate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
-  name: {{ .serviceName }}
+  name: selfsigned-issuer
   namespace: {{ .namespace }}
 spec:
-  selector:
-    app: eventshub-{{ .name }}
-  ports:
-    - protocol: TCP
-      name: http
-      port: 80
-      targetPort: 8080
-    {{ if .withEnforceTLS }}
-    - protocol: TCP
-      name: https
-      port: 443
-      targetPort: 8443
-    {{ end }}
+  selfSigned: {}

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -67,6 +67,7 @@ func Example() {
 	//     app: eventshub-hubhub
 	//   ports:
 	//     - protocol: TCP
+	//       name: http
 	//       port: 80
 	//       targetPort: 8080
 	// ---
@@ -141,6 +142,7 @@ func ExampleIstioAnnotation() {
 	//     app: eventshub-hubhub
 	//   ports:
 	//     - protocol: TCP
+	//       name: http
 	//       port: 80
 	//       targetPort: 8080
 	// ---
@@ -215,6 +217,7 @@ func ExampleNoReadiness() {
 	//     app: eventshub-hubhub
 	//   ports:
 	//     - protocol: TCP
+	//       name: http
 	//       port: 80
 	//       targetPort: 8080
 	// ---

--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -52,6 +52,13 @@ type EventsHubOption = func(context.Context, map[string]string) error
 // This can be used together with EchoEvent, ReplyWithTransformedEvent, ReplyWithAppendedData
 var StartReceiver EventsHubOption = envAdditive(EventGeneratorsEnv, "receiver")
 
+// StartReceiverTLS starts the receiver in the eventshub with TLS enforcement.
+// This can be used together with EchoEvent, ReplyWithTransformedEvent, ReplyWithAppendedData.
+//
+// It requires cert-manager operator to be able to create TLS Certificate.
+// To get the CA certificate used you can use GetCaCerts.
+var StartReceiverTLS EventsHubOption = compose(StartReceiver, envAdditive(EnforceTLS, "true"))
+
 // StartSender starts the sender in the eventshub
 // This can be used together with InputEvent, AddTracing, EnableIncrementalId, InputEncoding and InputHeader options
 func StartSender(sinkSvc string) EventsHubOption {

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -19,9 +19,13 @@ package eventshub
 import (
 	"context"
 	"embed"
+	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	eventshubrbac "knative.dev/reconciler-test/pkg/eventshub/rbac"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -29,6 +33,7 @@ import (
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/knativeservice"
+	"knative.dev/reconciler-test/pkg/resources/secret"
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
@@ -37,6 +42,16 @@ var servicePodTemplates embed.FS
 
 //go:embed 104-forwarder.yaml
 var forwarderTemplates embed.FS
+
+//go:embed 105-certificate-service.yaml
+var serviceTLSCertificate embed.FS
+
+//go:embed 105-issuer-ca.yaml 105-certificate-ca.yaml 105-issuer-certificate.yaml
+var caTLSCertificates embed.FS
+
+const (
+	caSecretName = "eventshub-ca"
+)
 
 // Install starts a new eventshub with the provided name
 // Note: this function expects that the Environment is configured with the
@@ -75,6 +90,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		eventshubrbac.Install()(ctx, t)
 
 		isReceiver := strings.Contains(envs[EventGeneratorsEnv], "receiver")
+		isEnforceTLS := strings.Contains(envs[EnforceTLS], "true")
 
 		var withForwarder bool
 		// Allow forwarder only when eventshub is receiver.
@@ -90,11 +106,12 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		}
 
 		cfg := map[string]interface{}{
-			"name":          name,
-			"serviceName":   serviceName,
-			"envs":          envs,
-			"image":         ImageFromContext(ctx),
-			"withReadiness": isReceiver,
+			"name":           name,
+			"serviceName":    serviceName,
+			"envs":           envs,
+			"image":          ImageFromContext(ctx),
+			"withReadiness":  isReceiver,
+			"withEnforceTLS": isEnforceTLS,
 		}
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
@@ -102,6 +119,12 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		}
 
 		manifest.PodSecurityCfgFn(ctx, t)(cfg)
+
+		if isEnforceTLS {
+			if _, err := manifest.InstallYamlFS(ctx, serviceTLSCertificate, cfg); err != nil {
+				log.Fatal(err)
+			}
+		}
 
 		// Deploy Service/Pod
 		if _, err := manifest.InstallYamlFS(ctx, servicePodTemplates, cfg); err != nil {
@@ -112,6 +135,10 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 
 		// If the eventhubs starts an event receiver, we need to wait for the service endpoint to be synced
 		if isReceiver {
+			if isEnforceTLS {
+				secret.IsPresent(fmt.Sprintf("server-tls-%s", name))(ctx, t)
+			}
+
 			k8s.WaitForServiceEndpointsOrFail(ctx, t, serviceName, 1)
 			k8s.WaitForServiceReadyOrFail(ctx, t, serviceName, "/health/ready")
 		}
@@ -135,4 +162,56 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			knativeservice.IsReady(name)
 		}
 	}
+}
+
+func WithTLS(t feature.T) environment.EnvOpts {
+	return func(ctx context.Context, env environment.Environment) (context.Context, error) {
+
+		return environment.WithPostInit(ctx, func(ctx context.Context, env environment.Environment) (context.Context, error) {
+
+			if _, err := manifest.InstallYamlFS(ctx, caTLSCertificates, nil); err != nil {
+				return ctx, fmt.Errorf("failed to install CA certificates and issuer: %w", err)
+			}
+
+			secret.IsPresent(caSecretName, secret.AssertKey("ca.crt"))(ctx, t)
+
+			caCerts, err := getCACertsFromSecret(ctx)
+			if err != nil {
+				return ctx, err
+			}
+			s := string(caCerts)
+			ctx = WithCaCerts(ctx, &s)
+
+			return ctx, nil
+		}), nil
+	}
+}
+
+type caCertsKey struct{}
+
+func WithCaCerts(ctx context.Context, caCerts *string) context.Context {
+	return context.WithValue(ctx, caCertsKey{}, caCerts)
+}
+
+func GetCaCerts(ctx context.Context) *string {
+	caCerts := ctx.Value(caCertsKey{})
+	if caCerts == nil {
+		return nil
+	}
+	return caCerts.(*string)
+}
+
+func getCACertsFromSecret(ctx context.Context) ([]byte, error) {
+	ns := environment.FromContext(ctx).Namespace()
+
+	s, err := kubeclient.Get(ctx).
+		CoreV1().
+		Secrets(ns).
+		Get(ctx, caSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get eventshub CA certs secret: %w", err)
+	}
+
+	caCrt, _ := s.Data["ca.crt"]
+	return caCrt, nil
 }

--- a/pkg/eventshub/utils.go
+++ b/pkg/eventshub/utils.go
@@ -37,6 +37,8 @@ const (
 	ConfigLoggingEnv   = "K_CONFIG_LOGGING"
 	EventGeneratorsEnv = "EVENT_GENERATORS"
 	EventLogsEnv       = "EVENT_LOGS"
+
+	EnforceTLS = "ENFORCE_TLS"
 )
 
 func ParseHeaders(serializedHeaders string) http.Header {

--- a/pkg/feature/context.go
+++ b/pkg/feature/context.go
@@ -29,11 +29,10 @@ func ContextWith(ctx context.Context, f *Feature) context.Context {
 }
 
 // FromContext returns the Feature from Context, if not found FromContext will
-// panic.
-// TODO: revisit if we really want to panic here... likely not.
+// return nil.
 func FromContext(ctx context.Context) *Feature {
 	if e, ok := ctx.Value(envKey{}).(*Feature); ok {
 		return e
 	}
-	panic("no Feature found in context")
+	return nil
 }

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -83,14 +83,14 @@ func WaitForReadyOrDone(ctx context.Context, t feature.T, ref corev1.ObjectRefer
 	case "jobs":
 		err := WaitUntilJobDone(ctx, t, ref.Name, interval, timeout)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed waiting for job done %+v %+v: %w", gvr, ref, err)
 		}
 		return nil
 
 	default:
 		err := WaitForResourceReady(ctx, t, ref.Namespace, ref.Name, gvr, interval, timeout)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed waiting for resource %+v %+v: %w", gvr, ref, err)
 		}
 	}
 

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
@@ -69,7 +70,9 @@ func InstallYamlFS(ctx context.Context, fsys fs.FS, base map[string]interface{})
 
 	// Save the refs to Environment and Feature
 	env.Reference(manifest.References()...)
-	f.Reference(manifest.References()...)
+	if f != nil {
+		f.Reference(manifest.References()...)
+	}
 
 	// Temp
 	refs := manifest.References()

--- a/pkg/resources/service/service.go
+++ b/pkg/resources/service/service.go
@@ -87,7 +87,6 @@ func AsDestinationRef(name string) *duckv1.Destination {
 	}
 }
 
-// Address
 func Address(ctx context.Context, name string) (*apis.URL, error) {
 	return k8s.Address(ctx, GVR(), name)
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -21,7 +21,7 @@ readonly root_dir
 
 source "${root_dir}/vendor/knative.dev/hack/e2e-tests.sh"
 
-function knative_setup() {
+function test_setup() {
   kubectl apply -f "${root_dir}/test/config" || return $?
 
   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml || return $?

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 
 set -Eeo pipefail
 
-rootdir="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")")"
-readonly rootdir
+root_dir="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")")"
+readonly root_dir
 
-source "${rootdir}/test/e2e-common.sh"
+source "${root_dir}/vendor/knative.dev/hack/e2e-tests.sh"
 
-initialize "$@"
+function knative_setup() {
+  kubectl apply -f "${root_dir}/test/config" || return $?
 
-set -Eeuo pipefail
-
-go_test_e2e -timeout 10m ./test/...
-
-success
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml || return $?
+  wait_until_pods_running cert-manager || return $?
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,7 +22,10 @@ readonly rootdir
 source "${rootdir}/vendor/knative.dev/hack/e2e-tests.sh"
 
 function knative_setup() {
-  kubectl apply -f "${rootdir}/test/config"
+  kubectl apply -f "${rootdir}/test/config" || return $?
+
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml || return $?
+  wait_until_pods_running cert-manager || return $?
 }
 
 initialize "$@"

--- a/test/e2e/eventshub/main_test.go
+++ b/test/e2e/eventshub/main_test.go
@@ -25,6 +25,7 @@ import (
 
 	// See: https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"knative.dev/reconciler-test/pkg/environment"
 )
 

--- a/test/e2e/eventshub/receiver_readiness.go
+++ b/test/e2e/eventshub/receiver_readiness.go
@@ -37,12 +37,13 @@ import (
 	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/yaml"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"sigs.k8s.io/yaml"
 )
 
 const ubi8Image = "registry.access.redhat.com/ubi8/ubi"

--- a/test/e2e/eventshub/receiver_tls_test.go
+++ b/test/e2e/eventshub/receiver_tls_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+	"knative.dev/reconciler-test/pkg/resources/secret"
+)
+
+func TestEventsHubReceiverTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		//environment.Managed(t), // Will call env.Finish() when the test exits.
+		eventshub.WithTLS(t),
+		knative.WithKnativeNamespace("knative-reconciler-test"),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+	)
+
+	caCerts := eventshub.GetCaCerts(ctx)
+	if caCerts == nil || len(*caCerts) == 0 {
+		t.Errorf("expected non empty CA certs")
+		return
+	}
+
+	env.Test(ctx, t, receiverTLS())
+}
+
+func receiverTLS() *feature.Feature {
+	f := feature.NewFeatureNamed("Receiver TLS")
+
+	sinkName := "sink"
+
+	f.Setup("deploy TLS receiver", eventshub.Install(sinkName, eventshub.StartReceiverTLS))
+
+	f.Requirement("CA secret is present", secret.IsPresent("eventshub-ca"))
+	f.Requirement("TLS certificate pair secret is present", secret.IsPresent(fmt.Sprintf("server-tls-%s", sinkName)))
+
+	f.Assert("get CA certs", func(ctx context.Context, t feature.T) {
+		caCerts := eventshub.GetCaCerts(ctx)
+		if caCerts == nil || len(*caCerts) == 0 {
+			t.Errorf("expected non empty CA certs")
+		}
+	})
+
+	return f
+}

--- a/test/e2e/eventshub/receiver_tls_test.go
+++ b/test/e2e/eventshub/receiver_tls_test.go
@@ -44,7 +44,7 @@ func TestEventsHubReceiverTLS(t *testing.T) {
 		k8s.WithEventListener,
 	)
 
-	env.Test(ctx, t, ensureCACerts())
+	env.Prerequisite(ctx, t, ensureCACerts())
 	env.Test(ctx, t, receiverTLS())
 }
 


### PR DESCRIPTION
This PR adds support to create a receiver with a TLS listener.

For test authors, to create a test with a TLS sink, it offers a few main
entry points:

- `eventshub.WithTLS` this is an `environment.EnvOpts`.
  it provision a root CA for a given environment (namespace) and makes
  CA certs for the root CA available in the environment's context

- `eventshub.StartReceiverTLS`, this is similar to
  the existing `eventshub.StartReceiver` with the addition of
  provisioning TLS key pair for the server based on the root CA

- `eventshub.GetCACerts` this is the method that can be used to retrieve
  the CA certs provisioned using `eventshub.WithTLS` on the environment.

When `eventshub.StartReceiverTLS` is used as option on `eventshub.Install`,
the eventshub receiver will enforce that requests are submitted only using
a TLS connection.

**Testing**

There is an e2e test, however, until we have #526, we cannot test it fully
with actual requests and events coming in.

However, I did a manual test that can be verified with the following (namespace might vary):

```shell
# 1. comment out environment.Managed(t) in the test so that the receiver won't be deleted at the end of the test

# 2. run the test
go test -count=1 -v -tags=e2e -run TestEventsHubReceiverTLS ./test/e2e/eventshub/

# 3. Get the CA certs and save it locally
kubectl get secrets -n test-uwvlipek eventshub-ca -o=jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt

# 4. Port forward receiver service locally
kubectl port-forward svc/sink 8443:443 -n test-uwvlipek

# 5. Verify connection is TLS and works without errors by providing the CA certs:
curl -v --cacert ca.crt https://127.0.0.1:8443/health/ready
# Example Output 
*   Trying 127.0.0.1:8443...
* Connected to 127.0.0.1 (127.0.0.1) port 8443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: ca.crt
*  CApath: none
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS header, Finished (20):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.2 (OUT), TLS header, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: O=local
*  start date: May 17 08:38:37 2023 GMT
*  expire date: May 17 09:38:37 2023 GMT
*  subjectAltName: host "127.0.0.1" matched cert's IP address!
*  issuer: CN=selfsigned-ca
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* h2h3 [:method: GET]
* h2h3 [:path: /health/ready]
* h2h3 [:scheme: https]
* h2h3 [:authority: 127.0.0.1:8443]
* h2h3 [user-agent: curl/7.85.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x55a3f6f74460)
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> GET /health/ready HTTP/2
> Host: 127.0.0.1:8443
> user-agent: curl/7.85.0
> accept: */*
> 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
< HTTP/2 200 
< content-type: text/plain; charset=utf-8
< content-length: 2
< date: Wed, 17 May 2023 08:46:39 GMT
< 
* Connection #0 to host 127.0.0.1 left intact

# 6. Verify that it fails when no CA certs is provided:
curl https://127.0.0.1:8443/health/ready
# Example output
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

Fixes https://github.com/knative/eventing/issues/6842

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>