### PR TITLE
eventshub RBAC resources independent to avoid deletion conflicts

### DIFF
--- a/pkg/eventshub/103-pod.yaml
+++ b/pkg/eventshub/103-pod.yaml
@@ -26,7 +26,7 @@ metadata:
       {{ end }}
   {{ end }}
 spec:
-  serviceAccountName: "{{ .namespace }}"
+  serviceAccountName: "{{ .name }}"
   restartPolicy: "OnFailure"
   {{ if .podSecurityContext }}
   securityContext:

--- a/pkg/eventshub/104-forwarder.yaml
+++ b/pkg/eventshub/104-forwarder.yaml
@@ -32,7 +32,7 @@ spec:
         {{ end }}
     {{ end }}
     spec:
-      serviceAccountName: "{{ .namespace }}"
+      serviceAccountName: "{{ .name }}"
       containers:
         - name: eventshub-forwarder
           image: {{ .image }}

--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -79,7 +79,7 @@ func Example() {
 	//   labels:
 	//     app: eventshub-hubhub
 	// spec:
-	//   serviceAccountName: "example"
+	//   serviceAccountName: "hubhub"
 	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
@@ -157,7 +157,7 @@ func ExampleIstioAnnotation() {
 	//       sidecar.istio.io/inject: "true"
 	//       sidecar.istio.io/rewriteAppHTTPProbers: "true"
 	// spec:
-	//   serviceAccountName: "example"
+	//   serviceAccountName: "hubhub"
 	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
@@ -229,7 +229,7 @@ func ExampleNoReadiness() {
 	//   labels:
 	//     app: eventshub-hubhub
 	// spec:
-	//   serviceAccountName: "example"
+	//   serviceAccountName: "hubhub"
 	//   restartPolicy: "OnFailure"
 	//   containers:
 	//     - name: eventshub
@@ -309,7 +309,7 @@ func ExampleForwarder() {
 	// spec:
 	//   template:
 	//     spec:
-	//       serviceAccountName: "example"
+	//       serviceAccountName: "hubhub"
 	//       containers:
 	//         - name: eventshub-forwarder
 	//           image: uri://a-real-container

--- a/pkg/eventshub/rbac/100-sa.yaml
+++ b/pkg/eventshub/rbac/100-sa.yaml
@@ -15,5 +15,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .namespace }}
+  name: {{ .name }}
   namespace: {{ .namespace }}

--- a/pkg/eventshub/rbac/101-rbac.yaml
+++ b/pkg/eventshub/rbac/101-rbac.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .namespace }}
+  name: {{ .name }}
   namespace: {{ .namespace }}
 rules:
   - apiGroups: [ "" ]
@@ -35,13 +35,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .namespace }}
+  name: {{ .name }}
   namespace: {{ .namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .namespace }}
+  name: {{ .name }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .namespace }}
+    name: {{ .name }}
     namespace: {{ .namespace }}

--- a/pkg/eventshub/rbac/rbac.go
+++ b/pkg/eventshub/rbac/rbac.go
@@ -31,9 +31,9 @@ var templates embed.FS
 
 // Install creates the necessary ServiceAccount, Role, RoleBinding for the eventshub.
 // The resources are named according to the current namespace defined in the environment.
-func Install() feature.StepFn {
+func Install(cfg map[string]interface{}) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := manifest.InstallYamlFS(ctx, templates, cfg); err != nil && !apierrors.IsAlreadyExists(err) {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/eventshub/rbac/rbac_test.go
+++ b/pkg/eventshub/rbac/rbac_test.go
@@ -31,6 +31,7 @@ func Example() {
 	ctx := testlog.NewContext()
 	files, err := manifest.ExecuteYAML(ctx, templates, nil,
 		map[string]interface{}{
+			"name":      "examplen",
 			"namespace": "example",
 		})
 	if err != nil {
@@ -42,13 +43,13 @@ func Example() {
 	// apiVersion: v1
 	// kind: ServiceAccount
 	// metadata:
-	//   name: example
+	//   name: examplen
 	//   namespace: example
 	// ---
 	// apiVersion: rbac.authorization.k8s.io/v1
 	// kind: Role
 	// metadata:
-	//   name: example
+	//   name: examplen
 	//   namespace: example
 	// rules:
 	//   - apiGroups: [ "" ]
@@ -66,14 +67,14 @@ func Example() {
 	// apiVersion: rbac.authorization.k8s.io/v1
 	// kind: RoleBinding
 	// metadata:
-	//   name: example
+	//   name: examplen
 	//   namespace: example
 	// roleRef:
 	//   apiGroup: rbac.authorization.k8s.io
 	//   kind: Role
-	//   name: example
+	//   name: examplen
 	// subjects:
 	//   - kind: ServiceAccount
-	//     name: example
+	//     name: examplen
 	//     namespace: example
 }

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -86,9 +86,6 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		eventListener := k8s.EventListenerFromContext(ctx)
 		registerEventsHubStore(ctx, eventListener, name, namespace)
 
-		// Install ServiceAccount, Role, RoleBinding
-		eventshubrbac.Install()(ctx, t)
-
 		isReceiver := strings.Contains(envs[EventGeneratorsEnv], "receiver")
 		isEnforceTLS := strings.Contains(envs[EnforceTLS], "true")
 
@@ -113,6 +110,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			"withReadiness":  isReceiver,
 			"withEnforceTLS": isEnforceTLS,
 		}
+
+		// Install ServiceAccount, Role, RoleBinding
+		eventshubrbac.Install(cfg)(ctx, t)
 
 		if ic := environment.GetIstioConfig(ctx); ic.Enabled {
 			manifest.WithIstioPodAnnotations(cfg)


### PR DESCRIPTION
By having [1] and the fact that:
- eventshub's RBAC resources are namespace global
- multiple parallel tests might run in a single namespace

we end up removing resources that are in active use by other tests.

[1] https://github.com/knative-sandbox/reconciler-test/commit/8a5db1ba56ec02538eec7de545365eae9ea3ced7