### PR TITLE
Support matching sender received peer certificates for certs rotation testing

### DIFF
--- a/pkg/eventshub/assert/step.go
+++ b/pkg/eventshub/assert/step.go
@@ -2,16 +2,21 @@ package assert
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
 type MatchAssertionBuilder struct {
 	storeName string
-	matchers  []eventshub.EventInfoMatcher
+	matchers  []eventshub.EventInfoMatcherCtx
 }
 
 // OnStore creates an assertion builder starting from the name of the store
@@ -24,35 +29,50 @@ func OnStore(name string) MatchAssertionBuilder {
 
 // Match adds the provided matchers in this builder
 func (m MatchAssertionBuilder) Match(matchers ...eventshub.EventInfoMatcher) MatchAssertionBuilder {
+	for _, matcher := range matchers {
+		m.matchers = append(m.matchers, matcher.WithContext())
+	}
+	return m
+}
+
+// MatchWithContext adds the provided matchers in this builder
+func (m MatchAssertionBuilder) MatchWithContext(matchers ...eventshub.EventInfoMatcherCtx) MatchAssertionBuilder {
+	m.matchers = append(m.matchers, matchers...)
+	return m
+}
+
+// MatchPeerCertificates adds the provided matchers in this builder
+func (m MatchAssertionBuilder) MatchPeerCertificatesReceived(matchers ...eventshub.EventInfoMatcherCtx) MatchAssertionBuilder {
+	m.matchers = append(m.matchers, MatchKind(eventshub.PeerCertificatesReceived).WithContext())
 	m.matchers = append(m.matchers, matchers...)
 	return m
 }
 
 // MatchReceivedEvent is a shortcut for Match(MatchKind(eventshub.EventReceived), MatchEvent(matchers...))
 func (m MatchAssertionBuilder) MatchReceivedEvent(matchers ...cetest.EventMatcher) MatchAssertionBuilder {
-	m.matchers = append(m.matchers, MatchKind(eventshub.EventReceived))
-	m.matchers = append(m.matchers, MatchEvent(matchers...))
+	m.matchers = append(m.matchers, MatchKind(eventshub.EventReceived).WithContext())
+	m.matchers = append(m.matchers, MatchEvent(matchers...).WithContext())
 	return m
 }
 
 // MatchRejectedEvent is a shortcut for Match(MatchKind(eventshub.EventRejected), MatchEvent(matchers...))
 func (m MatchAssertionBuilder) MatchRejectedEvent(matchers ...cetest.EventMatcher) MatchAssertionBuilder {
-	m.matchers = append(m.matchers, MatchKind(eventshub.EventRejected))
-	m.matchers = append(m.matchers, MatchEvent(matchers...))
+	m.matchers = append(m.matchers, MatchKind(eventshub.EventRejected).WithContext())
+	m.matchers = append(m.matchers, MatchEvent(matchers...).WithContext())
 	return m
 }
 
 // MatchSentEvent is a shortcut for Match(MatchKind(eventshub.EventSent), MatchEvent(matchers...))
 func (m MatchAssertionBuilder) MatchSentEvent(matchers ...cetest.EventMatcher) MatchAssertionBuilder {
-	m.matchers = append(m.matchers, MatchKind(eventshub.EventSent))
-	m.matchers = append(m.matchers, MatchEvent(matchers...))
+	m.matchers = append(m.matchers, MatchKind(eventshub.EventSent).WithContext())
+	m.matchers = append(m.matchers, MatchEvent(matchers...).WithContext())
 	return m
 }
 
 // MatchResponseEvent is a shortcut for Match(MatchKind(eventshub.EventResponse), MatchEvent(matchers...))
 func (m MatchAssertionBuilder) MatchResponseEvent(matchers ...cetest.EventMatcher) MatchAssertionBuilder {
-	m.matchers = append(m.matchers, MatchKind(eventshub.EventResponse))
-	m.matchers = append(m.matchers, MatchEvent(matchers...))
+	m.matchers = append(m.matchers, MatchKind(eventshub.EventResponse).WithContext())
+	m.matchers = append(m.matchers, MatchEvent(matchers...).WithContext())
 	return m
 }
 
@@ -61,8 +81,8 @@ func (m MatchAssertionBuilder) MatchEvent(matchers ...cetest.EventMatcher) Match
 	m.matchers = append(m.matchers, OneOf(
 		MatchKind(eventshub.EventReceived),
 		MatchKind(eventshub.EventSent),
-	))
-	m.matchers = append(m.matchers, MatchEvent(matchers...))
+	).WithContext())
+	m.matchers = append(m.matchers, MatchEvent(matchers...).WithContext())
 	return m
 }
 
@@ -70,7 +90,7 @@ func (m MatchAssertionBuilder) MatchEvent(matchers ...cetest.EventMatcher) Match
 // OnStore(store).Match(matchers).AtLeast(min) is equivalent to StoreFromContext(ctx, store).AssertAtLeast(min, matchers)
 func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(t, min, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertAtLeast(t, min, toFixedContextMatchers(ctx, m.matchers)...)
 	}
 }
 
@@ -78,7 +98,7 @@ func (m MatchAssertionBuilder) AtLeast(min int) feature.StepFn {
 // OnStore(store).Match(matchers).InRange(min, max) is equivalent to StoreFromContext(ctx, store).AssertInRange(min, max, matchers)
 func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(t, min, max, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertInRange(t, min, max, toFixedContextMatchers(ctx, m.matchers)...)
 	}
 }
 
@@ -86,7 +106,7 @@ func (m MatchAssertionBuilder) InRange(min int, max int) feature.StepFn {
 // OnStore(store).Match(matchers).Exact(n) is equivalent to StoreFromContext(ctx, store).AssertExact(n, matchers)
 func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(t, n, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertExact(t, n, toFixedContextMatchers(ctx, m.matchers)...)
 	}
 }
 
@@ -94,6 +114,44 @@ func (m MatchAssertionBuilder) Exact(n int) feature.StepFn {
 // OnStore(store).Match(matchers).Not() is equivalent to StoreFromContext(ctx, store).AssertNot(matchers)
 func (m MatchAssertionBuilder) Not() feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(t, m.matchers...)
+		eventshub.StoreFromContext(ctx, m.storeName).AssertNot(t, toFixedContextMatchers(ctx, m.matchers)...)
+	}
+}
+
+func toFixedContextMatchers(ctx context.Context, matchers []eventshub.EventInfoMatcherCtx) []eventshub.EventInfoMatcher {
+	out := make([]eventshub.EventInfoMatcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		out = append(out, matcher.WithContext(ctx))
+	}
+	return out
+}
+
+func MatchPeerCertificatesFromSecret(name string, key string) eventshub.EventInfoMatcherCtx {
+	return func(ctx context.Context, info eventshub.EventInfo) error {
+		secret, err := kubeclient.Get(ctx).CoreV1().
+			Secrets(environment.FromContext(ctx).Namespace()).
+			Get(ctx, name, metav1.GetOptions{})
+
+		if err != nil {
+			return fmt.Errorf("failed to get secret: %w", err)
+		}
+
+		value, ok := secret.Data[key]
+		if !ok {
+			return fmt.Errorf("failed to get value from secret %s/%s for key %s", secret.Namespace, secret.Name, key)
+		}
+
+		if info.Connection == nil && info.Connection.TLS == nil {
+			return fmt.Errorf("failed to match peer certificates, connection is not TLS")
+		}
+
+		for _, cert := range info.Connection.TLS.PemPeerCertificates {
+			if cert == string(value) {
+				return nil
+			}
+		}
+
+		bytes, _ := json.MarshalIndent(info.Connection.TLS.PemPeerCertificates, "", "  ")
+		return fmt.Errorf("failed to find peer certificate with value\n%s\nin:\n%s", string(value), string(bytes))
 	}
 }

--- a/pkg/eventshub/event_info_store.go
+++ b/pkg/eventshub/event_info_store.go
@@ -43,6 +43,23 @@ const (
 // EventInfoMatcher returns an error if the input event info doesn't match the criteria
 type EventInfoMatcher func(EventInfo) error
 
+// WithContext transforms EventInfoMatcher to EventInfoMatcherCtx.
+func (m EventInfoMatcher) WithContext() EventInfoMatcherCtx {
+	return func(ctx context.Context, info EventInfo) error {
+		return m(info)
+	}
+}
+
+// EventInfoMatcherCtx returns an error if the input event info doesn't match the criteria
+type EventInfoMatcherCtx func(context.Context, EventInfo) error
+
+// WithContext transforms EventInfoMatcherCtx to EventInfoMatcher.
+func (m EventInfoMatcherCtx) WithContext(ctx context.Context) EventInfoMatcher {
+	return func(info EventInfo) error {
+		return m(ctx, info)
+	}
+}
+
 // Stateful store of events published by eventshub pod it is pointed at.
 // Implements k8s.EventHandler
 type Store struct {

--- a/pkg/eventshub/receiver/receiver.go
+++ b/pkg/eventshub/receiver/receiver.go
@@ -253,7 +253,7 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		Time:        time.Now(),
 		Sequence:    s,
 		Kind:        kind,
-		Connection:  toConnection(request),
+		Connection:  eventshub.TLSConnectionStateToConnection(request.TLS),
 	}
 
 	if err := o.EventLogs.Vent(eventInfo); err != nil {
@@ -282,34 +282,6 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	}
 }
 
-func toConnection(request *http.Request) *eventshub.Connection {
-
-	if request.TLS != nil {
-		c := &eventshub.Connection{TLS: &eventshub.ConnectionTLS{}}
-		c.TLS.CipherSuite = request.TLS.CipherSuite
-		c.TLS.CipherSuiteName = tls.CipherSuiteName(request.TLS.CipherSuite)
-		c.TLS.HandshakeComplete = request.TLS.HandshakeComplete
-		c.TLS.IsInsecureCipherSuite = isInsecureCipherSuite(request.TLS)
-		return c
-	}
-
-	return nil
-}
-
 func isTLS(request *http.Request) bool {
-	return request.TLS != nil && request.TLS.HandshakeComplete && !isInsecureCipherSuite(request.TLS)
-}
-
-func isInsecureCipherSuite(conn *tls.ConnectionState) bool {
-	if conn == nil {
-		return true
-	}
-
-	res := false
-	for _, s := range tls.InsecureCipherSuites() {
-		if s.ID == conn.CipherSuite {
-			res = true
-		}
-	}
-	return res
+	return request.TLS != nil && request.TLS.HandshakeComplete && !eventshub.IsInsecureCipherSuite(request.TLS)
 }


### PR DESCRIPTION
For certificate rotation testing, we need to be able to match that the eventshub sender while sending requests received the "latest" / "rotated" peer certificate.

The use would look like this:
```golang
	f.Assert("Sender received expected peer certificate", assert.OnStore(sourceName).
		MatchPeerCertificatesReceived(assert.MatchPeerCertificatesFromSecret(secretName, "tls.crt")).
		AtLeast(1),
	)
```

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Support matching received peer certificates
- support defining matchers with context

Part of https://github.com/knative/eventing/issues/7039