### PR TITLE
Support rotating TLS certificates

### DIFF
--- a/resources/certificate/certificate.go
+++ b/resources/certificate/certificate.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/injection/clients/dynamicclient"
+
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+var (
+	certificateGVR = schema.GroupVersionResource{
+		Group:    "cert-manager.io",
+		Version:  "v1",
+		Resource: "certificates",
+	}
+)
+
+type RotateCertificate struct {
+	Certificate types.NamespacedName
+	Secret      types.NamespacedName
+}
+
+// Rotate rotates a cert-manager issued certificate.
+// The procedure follows the same process as the cert-manager command `cmctl renew <cert-name>`
+// See also https://cert-manager.io/docs/usage/certificate/#actions-triggering-private-key-rotation
+func Rotate(rotate RotateCertificate) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		before := getSecret(ctx, t, rotate)
+		issueRotation(ctx, t, rotate)
+		waitForRotation(ctx, t, rotate, before)
+	}
+
+}
+
+func issueRotation(ctx context.Context, t feature.T, rotate RotateCertificate) {
+	var lastErr error
+	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		err := rotateCertificate(ctx, rotate)
+		if err == nil {
+			return true, nil
+		}
+		lastErr = err
+
+		// Retry on conflicts
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+
+		return false, err
+	})
+	if err != nil {
+		t.Fatal(err, lastErr)
+	}
+}
+
+type Certificate struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Status Status `json:"status"`
+}
+
+// Status defines the observed state of Certificate
+type Status struct {
+	duckv1.Status `json:",inline"`
+	// Copied from https://github.com/cert-manager/cert-manager/blob/master/pkg/apis/certmanager/v1/types_certificate.go
+	LastFailureTime          *metav1.Time `json:"lastFailureTime,omitempty"`
+	NotBefore                *metav1.Time `json:"notBefore,omitempty"`
+	NotAfter                 *metav1.Time `json:"notAfter,omitempty"`
+	RenewalTime              *metav1.Time `json:"renewalTime,omitempty"`
+	Revision                 *int         `json:"revision,omitempty"`
+	NextPrivateKeySecretName *string      `json:"nextPrivateKeySecretName,omitempty"`
+	FailedIssuanceAttempts   *int         `json:"failedIssuanceAttempts,omitempty"`
+}
+
+func rotateCertificate(ctx context.Context, rotate RotateCertificate) error {
+	dc := dynamicclient.Get(ctx).Resource(certificateGVR)
+
+	obj, err := dc.
+		Namespace(rotate.Certificate.Namespace).
+		Get(ctx, rotate.Certificate.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	cert := &Certificate{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cert); err != nil {
+		return err
+	}
+
+	renewCertificate(cert)
+
+	obj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(cert)
+	if err != nil {
+		return err
+	}
+
+	_, err = dc.
+		Namespace(rotate.Certificate.Namespace).
+		UpdateStatus(ctx, obj, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func waitForRotation(ctx context.Context, t feature.T, rotate RotateCertificate, before *corev1.Secret) {
+	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		current := getSecret(ctx, t, rotate)
+		for k, v := range before.Data {
+			if !bytes.Equal(v, current.Data[k]) {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("Failed while waiting for Certificate rotation to happen: %v", err)
+	}
+}
+
+func getSecret(ctx context.Context, t feature.T, rotate RotateCertificate) *corev1.Secret {
+	secret, err := kubeclient.Get(ctx).
+		CoreV1().
+		Secrets(rotate.Secret.Namespace).
+		Get(ctx, rotate.Secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("Failed to get secret", err)
+	}
+
+	return secret
+}
+
+// Adapted from:
+// - https://github.com/cert-manager/cert-manager/blob/843deed22f563dbdcbbf71a9fc478609ee90cb8e/pkg/api/util/conditions.go#L165-L204
+// - https://github.com/cert-manager/cert-manager/blob/843deed22f563dbdcbbf71a9fc478609ee90cb8e/cmd/ctl/pkg/renew/renew.go#L206-L214
+func renewCertificate(c *Certificate) {
+
+	newCondition := apis.Condition{
+		Type:    apis.ConditionType("Issuing"),
+		Status:  corev1.ConditionTrue,
+		Reason:  "ManuallyTriggered",
+		Message: "Certificate re-issuance manually triggered",
+	}
+
+	nowTime := metav1.NewTime(time.Now())
+	newCondition.LastTransitionTime = apis.VolatileTime{Inner: nowTime}
+
+	// Search through existing conditions
+	for idx, cond := range c.Status.GetConditions() {
+		// Skip unrelated conditions
+		if cond.Type != newCondition.Type {
+			continue
+		}
+
+		// If this update doesn't contain a state transition, we don't update
+		// the conditions LastTransitionTime to Now()
+		if cond.Status == newCondition.Status {
+			newCondition.LastTransitionTime = cond.LastTransitionTime
+		}
+
+		// Overwrite the existing condition
+		c.Status.Conditions[idx] = newCondition
+		return
+	}
+
+	c.Status.SetConditions(append(c.Status.GetConditions(), newCondition))
+}

--- a/test/config/selfsigned-ca-issuer.yaml
+++ b/test/config/selfsigned-ca-issuer.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the issuer that every Eventing component should use to issue their server's certs.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-ca-issuer
+  namespace: knative-reconciler-test
+spec:
+  ca:
+    secretName: reconciler-test-ca

--- a/test/config/selfsigned-issuer.yaml
+++ b/test/config/selfsigned-issuer.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the root issuer to bootstrap the eventing CA.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: knative-reconciler-test
+spec:
+  selfSigned: {}
+---
+# This is the Eventing CA certificate.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+  namespace: knative-reconciler-test
+spec:
+  secretName: reconciler-test-ca
+
+  isCA: true
+  commonName: selfsigned-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/test/config/test-tls-certificate.yaml
+++ b/test/config/test-tls-certificate.yaml
@@ -1,0 +1,45 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-certificate
+  namespace: knative-reconciler-test
+spec:
+  # Secret names are always required.
+  secretName: test-certificate-tls
+
+  secretTemplate:
+    labels:
+      app.kubernetes.io/component: test-certificate
+
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+      - local
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+
+  dnsNames:
+    - test-certificate.knative-eventing.svc.cluster.local
+
+  issuerRef:
+    name: selfsigned-ca-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/test/config/test-tls-certificate.yaml
+++ b/test/config/test-tls-certificate.yaml
@@ -35,6 +35,7 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
+    rotationPolicy: Always
 
   dnsNames:
     - test-certificate.knative-eventing.svc.cluster.local

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -22,8 +22,8 @@ readonly root_dir
 source "${root_dir}/vendor/knative.dev/hack/e2e-tests.sh"
 
 function test_setup() {
-  kubectl apply -f "${root_dir}/test/config" || return $?
-
   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml || return $?
   wait_until_pods_running cert-manager || return $?
+
+  kubectl apply -f "${root_dir}/test/config" || return $?
 }

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -74,14 +74,15 @@ func TestRotateCertificates(t *testing.T) {
 
 	ns := "knative-reconciler-test"
 
+	secret := types.NamespacedName{
+		Namespace: ns,
+		Name:      "test-certificate-tls",
+	}
+
 	rc := certificate.RotateCertificate{
 		Certificate: types.NamespacedName{
 			Namespace: ns,
 			Name:      "test-certificate",
-		},
-		Secret: types.NamespacedName{
-			Namespace: ns,
-			Name:      "test-certificate-tls",
 		},
 	}
 
@@ -93,10 +94,10 @@ func TestRotateCertificates(t *testing.T) {
 		var err error
 		before, err = kubeclient.Get(ctx).
 			CoreV1().
-			Secrets(rc.Secret.Namespace).
-			Get(ctx, rc.Secret.Name, metav1.GetOptions{})
+			Secrets(secret.Namespace).
+			Get(ctx, secret.Name, metav1.GetOptions{})
 		if err != nil {
-			t.Errorf("Failed to get secret %s/%s: %v", rc.Secret.Namespace, rc.Secret.Name, err)
+			t.Errorf("Failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
 	})
 
@@ -105,10 +106,10 @@ func TestRotateCertificates(t *testing.T) {
 	f.Assert("verify different certificates", func(ctx context.Context, t feature.T) {
 		after, err := kubeclient.Get(ctx).
 			CoreV1().
-			Secrets(rc.Secret.Namespace).
-			Get(ctx, rc.Secret.Name, metav1.GetOptions{})
+			Secrets(secret.Namespace).
+			Get(ctx, secret.Name, metav1.GetOptions{})
 		if err != nil {
-			t.Errorf("Failed to get secret %s/%s: %v", rc.Secret.Namespace, rc.Secret.Name, err)
+			t.Errorf("Failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
 
 		if isEqualKey(before, after, "tls.key") {

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -23,12 +23,15 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/resources/cronjob"
+	"knative.dev/reconciler-test/resources/certificate"
 )
 
 func TestCronJobInstall(t *testing.T) {
@@ -58,4 +61,25 @@ func TestCronJobInstall(t *testing.T) {
 		AsFeature(),
 	)
 	env.Test(ctx, t, cronjob.AtLeastOneIsSucceeded(name).AsFeature())
+}
+
+func TestRotateCertificates(t *testing.T) {
+
+	ctx, env := global.Environment()
+
+	ns := "knative-reconciler-test"
+
+	env.Test(ctx, t,
+		certificate.Rotate(
+			certificate.RotateCertificate{
+				Certificate: types.NamespacedName{
+					Namespace: ns,
+					Name:      "test-certificate",
+				},
+				Secret: types.NamespacedName{
+					Namespace: ns,
+					Name:      "test-certificate-tls",
+				},
+			},
+		).AsFeature())
 }

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -112,11 +112,11 @@ func TestRotateCertificates(t *testing.T) {
 			t.Errorf("Failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
 
-		if isEqualKey(before, after, "tls.key") {
-			t.Errorf("Certificates rotation didn't happen tls.key is equal")
-		}
 		if isEqualKey(before, after, "tls.crt") {
 			t.Errorf("Certificates rotation didn't happen tls.crt is equal")
+		}
+		if isEqualKey(before, after, "tls.key") {
+			t.Errorf("Certificates rotation didn't happen tls.key is equal")
 		}
 	})
 


### PR DESCRIPTION
This PR adds a common StepFn for rotating a cert-manager certificates.

This PR in combination with https://github.com/knative-sandbox/reconciler-test/pull/548 will allow writing E2E cert-rotation tests that are generic for any implementation

Part of https://github.com/knative/eventing/issues/7039