### PR TITLE
Create a client and transport per request in the TLS case to force TLS handshakes

### DIFF
--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -144,6 +144,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventsh
 	}
 
 	httpClient := nethttp.DefaultClient
+	transport := nethttp.DefaultTransport.(*nethttp.Transport)
 
 	if env.EnforceTLS {
 		caCertPool, err := x509.SystemCertPool()
@@ -152,7 +153,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventsh
 		}
 		caCertPool.AppendCertsFromPEM([]byte(env.CACerts))
 
-		transport := nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+		transport = nethttp.DefaultTransport.(*nethttp.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs:    caCertPool,
 			MinVersion: tls.VersionTLS12,
@@ -202,6 +203,8 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventsh
 
 	ticker := time.NewTicker(period)
 	for {
+
+		transport.CloseIdleConnections()
 
 		ctx, span := trace.StartSpan(ctx, "eventshub-sender")
 

--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -154,6 +154,11 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventsh
 		caCertPool.AppendCertsFromPEM([]byte(env.CACerts))
 
 		transport = nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+
+		// Force multiple TLS handshakes
+		transport.DisableKeepAlives = true
+		transport.IdleConnTimeout = 500 * time.Millisecond
+
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs:    caCertPool,
 			MinVersion: tls.VersionTLS12,

--- a/test/e2e/eventshub/receiver_tls_test.go
+++ b/test/e2e/eventshub/receiver_tls_test.go
@@ -92,11 +92,11 @@ func receiverTLS() *feature.Feature {
 
 	f.Assert("Receive event", assert.OnStore(sinkName).
 		MatchReceivedEvent(cetest.HasId(event.ID())).
-		AtLeast(1),
+		AtLeast(10),
 	)
 	f.Assert("Sent event", assert.OnStore(sourceName).
 		MatchSentEvent(cetest.HasId(event.ID())).
-		AtLeast(1),
+		AtLeast(10),
 	)
 	f.Assert("Sender received expected peer certificate", assert.OnStore(sourceName).
 		MatchPeerCertificatesReceived(assert.MatchPeerCertificatesFromSecret(secretName, "tls.crt")).

--- a/test/e2e/eventshub/receiver_tls_test.go
+++ b/test/e2e/eventshub/receiver_tls_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
@@ -83,6 +84,7 @@ func receiverTLS() *feature.Feature {
 		eventshub.Install(sourceName,
 			eventshub.StartSenderToResourceTLS(eventshub.ReceiverGVR(ctx), sinkName, eventshub.GetCaCerts(ctx)),
 			eventshub.InputEvent(event),
+			eventshub.SendMultipleEvents(10, time.Second),
 		)(ctx, t)
 	})
 
@@ -98,7 +100,7 @@ func receiverTLS() *feature.Feature {
 	)
 	f.Assert("Sender received expected peer certificate", assert.OnStore(sourceName).
 		MatchPeerCertificatesReceived(assert.MatchPeerCertificatesFromSecret(secretName, "tls.crt")).
-		AtLeast(1),
+		AtLeast(5),
 	)
 
 	return f


### PR DESCRIPTION
For testing TLS certs rotation we need to force TLS handshakes multiple times