### PR TITLE
[release-1.10] Add name to port

### DIFF
--- a/pkg/eventshub/102-service.yaml
+++ b/pkg/eventshub/102-service.yaml
@@ -22,5 +22,6 @@ spec:
     app: eventshub-{{ .name }}
   ports:
     - protocol: TCP
+      name: http
       port: 80
       targetPort: 8080


### PR DESCRIPTION
This helps with Istio testing since without name istio doesn't know the protocol 

- https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
- https://istio.io/latest/docs/ops/common-problems/security-issues/#make-sure-you-are-not-using-http-only-fields-on-tcp-ports